### PR TITLE
Allow custom rendering for any node

### DIFF
--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNode.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNode.kt
@@ -6,7 +6,7 @@ package com.halilibo.richtext.markdown.node
  * @param type A sealed class which is categorized into block, container, and leaf nodes.
  * @param links Pointers to parent, sibling, child nodes.
  */
-internal data class AstNode(
+public data class AstNode(
   val type: AstNodeType,
   val links: AstNodeLinks
 )

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNodeLinks.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNodeLinks.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Immutable
  * All the pointers that can exist for a node in an AST.
  */
 @Immutable
-internal data class AstNodeLinks(
+public data class AstNodeLinks(
   var parent: AstNode? = null,
   var firstChild: AstNode? = null,
   var lastChild: AstNode? = null,

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNodeType.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNodeType.kt
@@ -23,32 +23,32 @@ import com.halilibo.richtext.ui.string.RichTextString
  * nodes are about styling(bold, italic, strikethrough, code). The rest contains links, images,
  * html content, and of course raw text.
  */
-internal sealed class AstNodeType
+public sealed class AstNodeType
 
 //region AstBlockNodeType
 
-internal sealed class AstBlockNodeType: AstNodeType()
+public sealed class AstBlockNodeType: AstNodeType()
 
 //region AstContainerBlockNodeType
 
-internal sealed class AstContainerBlockNodeType: AstBlockNodeType()
+public sealed class AstContainerBlockNodeType: AstBlockNodeType()
 
 @Immutable
-internal object AstDocument : AstContainerBlockNodeType()
+public object AstDocument : AstContainerBlockNodeType()
 
 @Immutable
-internal object AstBlockQuote : AstContainerBlockNodeType()
+public object AstBlockQuote : AstContainerBlockNodeType()
 
 @Immutable
-internal object AstListItem : AstContainerBlockNodeType()
+public object AstListItem : AstContainerBlockNodeType()
 
 @Immutable
-internal data class AstBulletList(
+public data class AstBulletList(
   val bulletMarker: Char
 ) : AstContainerBlockNodeType()
 
 @Immutable
-internal data class AstOrderedList(
+public data class AstOrderedList(
   val startNumber: Int,
   val delimiter: Char
 ) : AstContainerBlockNodeType()
@@ -57,23 +57,23 @@ internal data class AstOrderedList(
 
 //region AstLeafBlockNodeType
 
-internal sealed class AstLeafBlockNodeType: AstBlockNodeType()
+public sealed class AstLeafBlockNodeType: AstBlockNodeType()
 
 @Immutable
-internal object AstThematicBreak : AstLeafBlockNodeType()
+public object AstThematicBreak : AstLeafBlockNodeType()
 
 @Immutable
-internal data class AstHeading(
+public data class AstHeading(
   val level: Int
 ) : AstLeafBlockNodeType()
 
 @Immutable
-internal data class AstIndentedCodeBlock(
+public data class AstIndentedCodeBlock(
   val literal: String
 ) : AstLeafBlockNodeType()
 
 @Immutable
-internal data class AstFencedCodeBlock(
+public data class AstFencedCodeBlock(
   val fenceChar: Char,
   val fenceLength: Int,
   val fenceIndent: Int,
@@ -82,19 +82,19 @@ internal data class AstFencedCodeBlock(
 ) : AstLeafBlockNodeType()
 
 @Immutable
-internal data class AstHtmlBlock(
+public data class AstHtmlBlock(
   val literal: String
 ) : AstLeafBlockNodeType()
 
 @Immutable
-internal data class AstLinkReferenceDefinition(
+public data class AstLinkReferenceDefinition(
   val label: String,
   val destination: String,
   val title: String
 ) : AstLeafBlockNodeType()
 
 @Immutable
-internal object AstParagraph : AstLeafBlockNodeType()
+public object AstParagraph : AstLeafBlockNodeType()
 
 //endregion
 
@@ -102,48 +102,48 @@ internal object AstParagraph : AstLeafBlockNodeType()
 
 //region AstInlineNodeType
 
-internal sealed class AstInlineNodeType: AstNodeType()
+public sealed class AstInlineNodeType: AstNodeType()
 
 @Immutable
-internal data class AstCode(
+public data class AstCode(
   val literal: String
 ) : AstInlineNodeType()
 
 @Immutable
-internal data class AstEmphasis(
+public data class AstEmphasis(
   private val delimiter: String
 ) : AstInlineNodeType()
 
 @Immutable
-internal data class AstStrongEmphasis(
+public data class AstStrongEmphasis(
   private val delimiter: String
 ) : AstInlineNodeType()
 
 @Immutable
-internal data class AstLink(
+public data class AstLink(
   val destination: String,
   val title: String
 ) : AstInlineNodeType()
 
 @Immutable
-internal data class AstImage(
+public data class AstImage(
   val title: String,
   val destination: String
 ) : AstInlineNodeType()
 
 @Immutable
-internal data class AstHtmlInline(
+public data class AstHtmlInline(
   val literal: String
 ) : AstInlineNodeType()
 
 @Immutable
-internal object AstHardLineBreak : AstInlineNodeType()
+public object AstHardLineBreak : AstInlineNodeType()
 
 @Immutable
-internal object AstSoftLineBreak : AstInlineNodeType()
+public object AstSoftLineBreak : AstInlineNodeType()
 
 @Immutable
-internal data class AstText(
+public data class AstText(
   val literal: String
 ) : AstInlineNodeType()
 


### PR DESCRIPTION
This allows you to override the rendering of specific nodes such as a code block.