### PR TITLE
Make images clickable if any of their parents are links and allow contentOverride for more nodes

### DIFF
--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -1,6 +1,7 @@
 package com.halilibo.richtext.markdown
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -27,6 +28,7 @@ private val DEFAULT_IMAGE_SIZE = 64.dp
 internal actual fun RemoteImage(
   url: String,
   contentDescription: String?,
+  onClick: (() -> Unit)?,
   modifier: Modifier,
   contentScale: ContentScale
 ) {
@@ -40,7 +42,9 @@ internal actual fun RemoteImage(
 
   val density = LocalDensity.current
 
-  BoxWithConstraints(modifier, contentAlignment = Alignment.Center) {
+  BoxWithConstraints(
+    modifier = if (onClick == null) modifier else modifier.clickable(onClick = onClick),
+    contentAlignment = Alignment.Center) {
     val sizeModifier by remember(density, painter) {
       derivedStateOf {
         val painterIntrinsicSize = painter.state.painter?.intrinsicSize

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -171,7 +171,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
     }
     is AstHeading -> {
       Heading(level = astNodeType.level) {
-        MarkdownRichText(astNode, Modifier.semantics { heading() } )
+        MarkdownRichText(astNode, contentOverride, Modifier.semantics { heading() } )
       }
     }
     is AstIndentedCodeBlock -> {
@@ -192,10 +192,10 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
       /* no-op */
     }
     is AstParagraph -> {
-      MarkdownRichText(astNode)
+      MarkdownRichText(astNode, contentOverride)
     }
     is AstTableRoot -> {
-      RenderTable(astNode)
+      RenderTable(astNode, contentOverride)
     }
     // This should almost never happen. All the possible text
     // nodes must be under either Heading, Paragraph or CustomNode

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -104,11 +104,16 @@ private fun computeRichTextString(
                 IntSize(128.dp.roundToPx(), 128.dp.roundToPx())
               }
             ) {
+              val parentDestination = currentNode.links.firstParentOrNull<AstLink>()?.destination
               RemoteImage(
                 url = currentNodeType.destination,
                 contentDescription = currentNodeType.title,
                 modifier = Modifier.fillMaxWidth(),
-                contentScale = ContentScale.Inside
+                contentScale = ContentScale.Inside,
+                onClick = when (parentDestination) {
+                  null -> null
+                  else -> {{ onLinkClicked(parentDestination) }}
+                },
               )
             }
           )

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -56,18 +56,23 @@ import com.halilibo.richtext.ui.string.withFormat
  * @param astNode Root node to accept as Text Content container.
  */
 @Composable
-internal fun RichTextScope.MarkdownRichText(astNode: AstNode, modifier: Modifier = Modifier) {
+internal fun RichTextScope.MarkdownRichText(
+  astNode: AstNode,
+  contentOverride: ContentOverride?,
+  modifier: Modifier = Modifier
+) {
   val onLinkClicked = LocalOnLinkClicked.current
   // Assume that only RichText nodes reside below this level.
   val richText = remember(astNode, onLinkClicked) {
-    computeRichTextString(astNode, onLinkClicked)
+    computeRichTextString(astNode, contentOverride, onLinkClicked)
   }
 
   Text(text = richText, modifier = modifier)
 }
 
-private fun computeRichTextString(
+private fun RichTextScope.computeRichTextString(
   astNode: AstNode,
+  contentOverride: ContentOverride?,
   onLinkClicked: (String) -> Unit
 ): RichTextString {
   val richTextStringBuilder = RichTextString.Builder()
@@ -93,10 +98,12 @@ private fun computeRichTextString(
           }
           null
         }
+
         is AstEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Italic)
         is AstStrikethrough -> richTextStringBuilder.pushFormat(
           RichTextString.Format.Strikethrough
         )
+
         is AstImage -> {
           richTextStringBuilder.appendInlineContent(
             content = InlineContent(
@@ -104,41 +111,51 @@ private fun computeRichTextString(
                 IntSize(128.dp.roundToPx(), 128.dp.roundToPx())
               }
             ) {
-              val parentDestination = currentNode.links.firstParentOrNull<AstLink>()?.destination
-              RemoteImage(
-                url = currentNodeType.destination,
-                contentDescription = currentNodeType.title,
-                modifier = Modifier.fillMaxWidth(),
-                contentScale = ContentScale.Inside,
-                onClick = when (parentDestination) {
-                  null -> null
-                  else -> {{ onLinkClicked(parentDestination) }}
-                },
-              )
+              if (contentOverride?.invoke(this@computeRichTextString, currentNode) {} != true) {
+                val parentDestination = currentNode.links.firstParentOrNull<AstLink>()?.destination
+                RemoteImage(
+                  url = currentNodeType.destination,
+                  contentDescription = currentNodeType.title,
+                  modifier = Modifier.fillMaxWidth(),
+                  contentScale = ContentScale.Inside,
+                  onClick = when (parentDestination) {
+                    null -> null
+                    else -> {
+                      { onLinkClicked(parentDestination) }
+                    }
+                  },
+                )
+              }
             }
           )
           null
         }
+
         is AstLink -> richTextStringBuilder.pushFormat(RichTextString.Format.Link(
           onClick = { onLinkClicked(currentNodeType.destination) }
         ))
+
         is AstSoftLineBreak -> {
           richTextStringBuilder.append(" ")
           null
         }
+
         is AstHardLineBreak -> {
           richTextStringBuilder.append("\n")
           null
         }
+
         is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
         is AstText -> {
           richTextStringBuilder.append(currentNodeType.literal)
           null
         }
+
         is AstLinkReferenceDefinition -> richTextStringBuilder.pushFormat(
           RichTextString.Format.Link(
             onClick = { onLinkClicked(currentNodeType.destination) }
           ))
+
         else -> null
       }
 

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.layout.ContentScale
 internal expect fun RemoteImage(
   url: String,
   contentDescription: String?,
+  onClick: (() -> Unit)?,
   modifier: Modifier = Modifier,
   contentScale: ContentScale
 )

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -10,7 +10,7 @@ import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.Table
 
 @Composable
-internal fun RichTextScope.RenderTable(node: AstNode) {
+internal fun RichTextScope.RenderTable(node: AstNode, contentOverride: ContentOverride?) {
   Table(
     headerRow = {
       node.filterChildrenType<AstTableHeader>()
@@ -20,7 +20,7 @@ internal fun RichTextScope.RenderTable(node: AstNode) {
         ?.filterChildrenType<AstTableCell>()
         ?.forEach { tableCell ->
           cell {
-            MarkdownRichText(tableCell)
+            MarkdownRichText(tableCell, contentOverride)
           }
         }
     }
@@ -33,7 +33,7 @@ internal fun RichTextScope.RenderTable(node: AstNode) {
           tableRow.filterChildrenType<AstTableCell>()
             .forEach { tableCell ->
               cell {
-                MarkdownRichText(tableCell)
+                MarkdownRichText(tableCell, contentOverride)
               }
             }
         }

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNodeLinks.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/node/AstNodeLinks.kt
@@ -14,6 +14,15 @@ public data class AstNodeLinks(
   var next: AstNode? = null
 ) {
 
+  internal inline fun <reified T : AstNodeType> firstParentOrNull(): T? {
+    var parent = this.parent
+    while (parent != null) {
+      if (parent.type is T) return parent.type as T
+      parent = parent.links.parent
+    }
+    return null
+  }
+
   /**
    * Stop infinite loop and only check towards bottom-right direction
    */

--- a/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -1,6 +1,7 @@
 package com.halilibo.richtext.markdown
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
@@ -23,6 +24,7 @@ import javax.imageio.ImageIO
 internal actual fun RemoteImage(
   url: String,
   contentDescription: String?,
+  onClick: (() -> Unit)?,
   modifier: Modifier,
   contentScale: ContentScale
 ) {
@@ -36,7 +38,7 @@ internal actual fun RemoteImage(
     Image(
       bitmap = image!!,
       contentDescription = contentDescription,
-      modifier = modifier,
+      modifier = if (onClick == null) modifier else modifier.clickable(onClick = onClick),
       contentScale = contentScale
     )
   }


### PR DESCRIPTION
1. I discovered that only the left side of images that are embedded in markdown links are currently clickable. This changes it so that images that have a parent link will inherit the click handling of their parent link.
2. There were some nodes that weren't handled by contentOverride such as the display content for a link. This expands contentOverride to work for more things.