### PR TITLE
Add inlineContentOverride

### DIFF
--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -28,7 +28,6 @@ private val DEFAULT_IMAGE_SIZE = 64.dp
 internal actual fun RemoteImage(
   url: String,
   contentDescription: String?,
-  onClick: (() -> Unit)?,
   modifier: Modifier,
   contentScale: ContentScale
 ) {
@@ -43,7 +42,7 @@ internal actual fun RemoteImage(
   val density = LocalDensity.current
 
   BoxWithConstraints(
-    modifier = if (onClick == null) modifier else modifier.clickable(onClick = onClick),
+    modifier = modifier,
     contentAlignment = Alignment.Center) {
     val sizeModifier by remember(density, painter) {
       derivedStateOf {

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -43,14 +43,21 @@ import com.halilibo.richtext.ui.string.Text
 import com.halilibo.richtext.ui.string.richTextString
 import org.commonmark.node.Node
 
+/**
+ * Overrides block content such as code blocks.
+ */
 public typealias ContentOverride = @Composable (
   node: AstNode,
   visitChildren: @Composable (node: AstNode) -> Unit,
 ) -> Boolean
 
+/**
+ * Overrides content that is inline in a paragraph such as a link, or text.
+ */
 public typealias InlineContentOverride = RichTextScope.(
   node: AstNode,
   richTextStringBuilder: RichTextString.Builder,
+  onClick: (() -> Unit)?,
 ) -> InlineContent?
 
 /**

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -38,14 +38,20 @@ import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.string.InlineContent
+import com.halilibo.richtext.ui.string.RichTextString
 import com.halilibo.richtext.ui.string.Text
 import com.halilibo.richtext.ui.string.richTextString
 import org.commonmark.node.Node
 
-public typealias ContentOverride = @Composable RichTextScope.(
+public typealias ContentOverride = @Composable (
   node: AstNode,
   visitChildren: @Composable (node: AstNode) -> Unit,
 ) -> Boolean
+
+public typealias InlineContentOverride = RichTextScope.(
+  node: AstNode,
+  richTextStringBuilder: RichTextString.Builder,
+) -> InlineContent?
 
 /**
  * A composable that renders Markdown content using RichText.
@@ -60,9 +66,10 @@ public fun RichTextScope.Markdown(
   markdownParseOptions: MarkdownParseOptions = MarkdownParseOptions.Default,
   onLinkClicked: ((String) -> Unit)? = null,
   contentOverride: ContentOverride? = null,
+  inlineContentOverride: InlineContentOverride? = null,
 ) {
   val markdown = parsedMarkdown(text = content, options = markdownParseOptions)
-  markdown?.let { Markdown(it, onLinkClicked, contentOverride) }
+  markdown?.let { Markdown(it, onLinkClicked, contentOverride, inlineContentOverride) }
 }
 
 /**
@@ -76,6 +83,7 @@ public fun RichTextScope.Markdown(
   content: Node,
   onLinkClicked: ((String) -> Unit)? = null,
   contentOverride: ContentOverride? = null,
+  inlineContentOverride: InlineContentOverride? = null,
 ) {
   val onLinkClickedState = rememberUpdatedState(onLinkClicked)
   // Can't use UriHandlerAmbient.current::openUri here,
@@ -86,7 +94,7 @@ public fun RichTextScope.Markdown(
     }
   }
   CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
-    RecursiveRenderMarkdownAst(astNode = content.toAstNode(), contentOverride)
+    RecursiveRenderMarkdownAst(content.toAstNode(), contentOverride, inlineContentOverride)
   }
 }
 
@@ -136,50 +144,60 @@ internal expect fun parsedMarkdown(text: String, options: MarkdownParseOptions):
 internal fun RichTextScope.RecursiveRenderMarkdownAst(
   astNode: AstNode?,
   contentOverride: ContentOverride?,
+  inlineContentOverride: InlineContentOverride?,
 ) {
   astNode ?: return
 
-  if (contentOverride?.invoke(this, astNode) { visitChildren(it, contentOverride) } == true) {
+  if (contentOverride?.invoke(astNode) {
+      visitChildren(it, contentOverride, inlineContentOverride)
+    } == true) {
     return
   }
 
   when (val astNodeType = astNode.type) {
-    is AstDocument -> visitChildren(node = astNode, contentOverride)
+    is AstDocument -> visitChildren(node = astNode, contentOverride, inlineContentOverride)
     is AstBlockQuote -> {
       BlockQuote {
-        visitChildren(astNode, contentOverride)
+        visitChildren(astNode, contentOverride, inlineContentOverride)
       }
     }
+
     is AstBulletList -> {
       FormattedList(
         listType = Unordered,
         items = astNode.filterChildrenType<AstListItem>().toList()
       ) {
-        visitChildren(it, contentOverride)
+        visitChildren(it, contentOverride, inlineContentOverride)
       }
     }
+
     is AstOrderedList -> {
       FormattedList(
         listType = Ordered,
         items = astNode.childrenSequence().toList()
       ) { astListItem ->
-        visitChildren(astListItem, contentOverride)
+        visitChildren(astListItem, contentOverride, inlineContentOverride)
       }
     }
+
     is AstThematicBreak -> {
       HorizontalRule()
     }
+
     is AstHeading -> {
       Heading(level = astNodeType.level) {
-        MarkdownRichText(astNode, contentOverride, Modifier.semantics { heading() } )
+        MarkdownRichText(astNode, inlineContentOverride, Modifier.semantics { heading() })
       }
     }
+
     is AstIndentedCodeBlock -> {
       CodeBlock(text = astNodeType.literal.trim())
     }
+
     is AstFencedCodeBlock -> {
       CodeBlock(text = astNodeType.literal.trim())
     }
+
     is AstHtmlBlock -> {
       Text(text = richTextString {
         appendInlineContent(content = InlineContent {
@@ -187,15 +205,18 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
         })
       })
     }
+
     is AstLinkReferenceDefinition -> {
       // TODO(halilozercan)
       /* no-op */
     }
+
     is AstParagraph -> {
-      MarkdownRichText(astNode, contentOverride)
+      MarkdownRichText(astNode, inlineContentOverride)
     }
+
     is AstTableRoot -> {
-      RenderTable(astNode, contentOverride)
+      RenderTable(astNode, inlineContentOverride)
     }
     // This should almost never happen. All the possible text
     // nodes must be under either Heading, Paragraph or CustomNode
@@ -206,13 +227,16 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
       println("Unexpected raw text while traversing the Abstract Syntax Tree.")
       Text(richTextString { append(astNodeType.literal) })
     }
+
     is AstListItem -> {
       println("MarkdownRichText: Unexpected AstListItem while traversing the Abstract Syntax Tree.")
     }
+
     is AstInlineNodeType -> {
       // ignore
       println("MarkdownRichText: Unexpected AstInlineNodeType $astNodeType while traversing the Abstract Syntax Tree.")
     }
+
     AstTableBody,
     AstTableHeader,
     AstTableRow,
@@ -228,9 +252,13 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
  * @param node Root ASTNode whose children will be visited.
  */
 @Composable
-internal fun RichTextScope.visitChildren(node: AstNode?, contentOverride: ContentOverride?) {
+internal fun RichTextScope.visitChildren(
+  node: AstNode?,
+  contentOverride: ContentOverride?,
+  inlineContentOverride: InlineContentOverride?,
+) {
   node?.childrenSequence()?.forEach {
-    RecursiveRenderMarkdownAst(astNode = it, contentOverride)
+    RecursiveRenderMarkdownAst(astNode = it, contentOverride, inlineContentOverride)
   }
 }
 

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -91,8 +91,14 @@ private fun RichTextScope.computeRichTextString(
     iteratorStack = iteratorStack.drop(1)
 
     if (!isVisited) {
+      val parentLink = currentNode.links.firstParentOrNull<AstLink>()
       val newFormatIndex =
-        when (val override = inlineContentOverride?.invoke(this, currentNode, richTextStringBuilder)) {
+        when (val override = inlineContentOverride?.invoke(
+          this,
+          currentNode,
+          richTextStringBuilder,
+          if (parentLink == null) null else {{ onLinkClicked(parentLink.destination) }},
+        )) {
           null -> when (val currentNodeType = currentNode.type) {
             is AstCode -> {
               richTextStringBuilder.withFormat(RichTextString.Format.Code) {
@@ -113,18 +119,11 @@ private fun RichTextScope.computeRichTextString(
                     IntSize(128.dp.roundToPx(), 128.dp.roundToPx())
                   }
                 ) {
-                  val parentLink = currentNode.links.firstParentOrNull<AstLink>()
                   RemoteImage(
                     url = currentNodeType.destination,
                     contentDescription = currentNodeType.title,
                     modifier = Modifier.fillMaxWidth(),
                     contentScale = ContentScale.Inside,
-                    onClick = when (parentLink) {
-                      null -> null
-                      else -> {
-                        { onLinkClicked(parentLink.destination) }
-                      }
-                    },
                   )
 
                 }

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -58,13 +58,13 @@ import com.halilibo.richtext.ui.string.withFormat
 @Composable
 internal fun RichTextScope.MarkdownRichText(
   astNode: AstNode,
-  contentOverride: ContentOverride?,
+  inlineContentOverride: InlineContentOverride?,
   modifier: Modifier = Modifier
 ) {
   val onLinkClicked = LocalOnLinkClicked.current
   // Assume that only RichText nodes reside below this level.
   val richText = remember(astNode, onLinkClicked) {
-    computeRichTextString(astNode, contentOverride, onLinkClicked)
+    computeRichTextString(astNode, inlineContentOverride, onLinkClicked)
   }
 
   Text(text = richText, modifier = modifier)
@@ -72,7 +72,7 @@ internal fun RichTextScope.MarkdownRichText(
 
 private fun RichTextScope.computeRichTextString(
   astNode: AstNode,
-  contentOverride: ContentOverride?,
+  inlineContentOverride: InlineContentOverride?,
   onLinkClicked: (String) -> Unit
 ): RichTextString {
   val richTextStringBuilder = RichTextString.Builder()
@@ -91,73 +91,80 @@ private fun RichTextScope.computeRichTextString(
     iteratorStack = iteratorStack.drop(1)
 
     if (!isVisited) {
-      val newFormatIndex = when (val currentNodeType = currentNode.type) {
-        is AstCode -> {
-          richTextStringBuilder.withFormat(RichTextString.Format.Code) {
-            append(currentNodeType.literal)
-          }
-          null
-        }
-
-        is AstEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Italic)
-        is AstStrikethrough -> richTextStringBuilder.pushFormat(
-          RichTextString.Format.Strikethrough
-        )
-
-        is AstImage -> {
-          richTextStringBuilder.appendInlineContent(
-            content = InlineContent(
-              initialSize = {
-                IntSize(128.dp.roundToPx(), 128.dp.roundToPx())
+      val newFormatIndex =
+        when (val override = inlineContentOverride?.invoke(this, currentNode, richTextStringBuilder)) {
+          null -> when (val currentNodeType = currentNode.type) {
+            is AstCode -> {
+              richTextStringBuilder.withFormat(RichTextString.Format.Code) {
+                append(currentNodeType.literal)
               }
-            ) {
-              if (contentOverride?.invoke(this@computeRichTextString, currentNode) {} != true) {
-                val parentDestination = currentNode.links.firstParentOrNull<AstLink>()?.destination
-                RemoteImage(
-                  url = currentNodeType.destination,
-                  contentDescription = currentNodeType.title,
-                  modifier = Modifier.fillMaxWidth(),
-                  contentScale = ContentScale.Inside,
-                  onClick = when (parentDestination) {
-                    null -> null
-                    else -> {
-                      { onLinkClicked(parentDestination) }
-                    }
-                  },
-                )
-              }
+              null
             }
-          )
-          null
+
+            is AstEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Italic)
+            is AstStrikethrough -> richTextStringBuilder.pushFormat(
+              RichTextString.Format.Strikethrough
+            )
+
+            is AstImage -> {
+              richTextStringBuilder.appendInlineContent(
+                content = InlineContent(
+                  initialSize = {
+                    IntSize(128.dp.roundToPx(), 128.dp.roundToPx())
+                  }
+                ) {
+                  val parentLink = currentNode.links.firstParentOrNull<AstLink>()
+                  RemoteImage(
+                    url = currentNodeType.destination,
+                    contentDescription = currentNodeType.title,
+                    modifier = Modifier.fillMaxWidth(),
+                    contentScale = ContentScale.Inside,
+                    onClick = when (parentLink) {
+                      null -> null
+                      else -> {
+                        { onLinkClicked(parentLink.destination) }
+                      }
+                    },
+                  )
+
+                }
+              )
+              null
+            }
+
+            is AstLink -> richTextStringBuilder.pushFormat(RichTextString.Format.Link(
+              onClick = { onLinkClicked(currentNodeType.destination) }
+            ))
+
+            is AstSoftLineBreak -> {
+              richTextStringBuilder.append(" ")
+              null
+            }
+
+            is AstHardLineBreak -> {
+              richTextStringBuilder.append("\n")
+              null
+            }
+
+            is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
+            is AstText -> {
+              richTextStringBuilder.append(currentNodeType.literal)
+              null
+            }
+
+            is AstLinkReferenceDefinition -> richTextStringBuilder.pushFormat(
+              RichTextString.Format.Link(
+                onClick = { onLinkClicked(currentNodeType.destination) }
+              ))
+
+            else -> null
+          }
+
+          else -> {
+            richTextStringBuilder.appendInlineContent(content = override)
+            null
+          }
         }
-
-        is AstLink -> richTextStringBuilder.pushFormat(RichTextString.Format.Link(
-          onClick = { onLinkClicked(currentNodeType.destination) }
-        ))
-
-        is AstSoftLineBreak -> {
-          richTextStringBuilder.append(" ")
-          null
-        }
-
-        is AstHardLineBreak -> {
-          richTextStringBuilder.append("\n")
-          null
-        }
-
-        is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
-        is AstText -> {
-          richTextStringBuilder.append(currentNodeType.literal)
-          null
-        }
-
-        is AstLinkReferenceDefinition -> richTextStringBuilder.pushFormat(
-          RichTextString.Format.Link(
-            onClick = { onLinkClicked(currentNodeType.destination) }
-          ))
-
-        else -> null
-      }
 
       iteratorStack = iteratorStack.addFirst(
         AstNodeTraversalEntry(

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.layout.ContentScale
 internal expect fun RemoteImage(
   url: String,
   contentDescription: String?,
-  onClick: (() -> Unit)?,
   modifier: Modifier = Modifier,
   contentScale: ContentScale
 )

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -10,7 +10,10 @@ import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.Table
 
 @Composable
-internal fun RichTextScope.RenderTable(node: AstNode, contentOverride: ContentOverride?) {
+internal fun RichTextScope.RenderTable(
+  node: AstNode,
+  inlineContentOverride: InlineContentOverride?,
+) {
   Table(
     headerRow = {
       node.filterChildrenType<AstTableHeader>()
@@ -20,7 +23,7 @@ internal fun RichTextScope.RenderTable(node: AstNode, contentOverride: ContentOv
         ?.filterChildrenType<AstTableCell>()
         ?.forEach { tableCell ->
           cell {
-            MarkdownRichText(tableCell, contentOverride)
+            MarkdownRichText(tableCell, inlineContentOverride)
           }
         }
     }
@@ -33,7 +36,7 @@ internal fun RichTextScope.RenderTable(node: AstNode, contentOverride: ContentOv
           tableRow.filterChildrenType<AstTableCell>()
             .forEach { tableCell ->
               cell {
-                MarkdownRichText(tableCell, contentOverride)
+                MarkdownRichText(tableCell, inlineContentOverride)
               }
             }
         }

--- a/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -24,7 +24,6 @@ import javax.imageio.ImageIO
 internal actual fun RemoteImage(
   url: String,
   contentDescription: String?,
-  onClick: (() -> Unit)?,
   modifier: Modifier,
   contentScale: ContentScale
 ) {
@@ -38,7 +37,7 @@ internal actual fun RemoteImage(
     Image(
       bitmap = image!!,
       contentDescription = contentDescription,
-      modifier = if (onClick == null) modifier else modifier.clickable(onClick = onClick),
+      modifier = modifier,
       contentScale = contentScale
     )
   }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/InlineContent.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/InlineContent.kt
@@ -2,6 +2,8 @@
 
 package com.halilibo.richtext.ui.string
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -9,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.Placeholder
@@ -41,7 +44,8 @@ public class InlineContent(
  */
 @Composable internal fun manageInlineTextContents(
   inlineContents: Map<String, InlineContent>,
-  textConstraints: Constraints
+  textConstraints: Constraints,
+  onClick: (() -> Unit)?,
 ): Map<String, InlineTextContent> {
   val density = LocalDensity.current
 
@@ -49,7 +53,8 @@ public class InlineContent(
     reifyInlineContent(
       content,
       Constraints(maxWidth = textConstraints.maxWidth, maxHeight = textConstraints.maxHeight),
-      density
+      density,
+      onClick,
     )
   }
 }
@@ -63,7 +68,8 @@ public class InlineContent(
 @Composable private fun reifyInlineContent(
   content: InlineContent,
   contentConstraints: Constraints,
-  density: Density
+  density: Density,
+  onClick: (() -> Unit)?,
 ): InlineTextContent {
   var size by remember {
     mutableStateOf(
@@ -82,7 +88,19 @@ public class InlineContent(
     )
 
     return InlineTextContent(placeholder) { alternateText ->
-      Layout(content = { content.content(this, alternateText) }) { measurables, _ ->
+      val wrappedContents = @Composable {
+        when (onClick) {
+          null -> content.content(density, alternateText)
+          else -> Box(
+            modifier = Modifier
+              .clickable(onClick = onClick)
+          ) {
+            content.content(density, alternateText)
+          }
+        }
+      }
+
+      Layout(content = wrappedContents) { measurables, _ ->
         // Measure the content with the constraints for the parent Text layout, not the actual.
         // This allows it to determine exactly how large it needs to be so we can update the
         // placeholder.

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/InlineContent.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/InlineContent.kt
@@ -2,8 +2,6 @@
 
 package com.halilibo.richtext.ui.string
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -11,7 +9,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.structuralEqualityPolicy
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.Placeholder
@@ -45,7 +42,6 @@ public class InlineContent(
 @Composable internal fun manageInlineTextContents(
   inlineContents: Map<String, InlineContent>,
   textConstraints: Constraints,
-  onClick: (() -> Unit)?,
 ): Map<String, InlineTextContent> {
   val density = LocalDensity.current
 
@@ -54,7 +50,6 @@ public class InlineContent(
       content,
       Constraints(maxWidth = textConstraints.maxWidth, maxHeight = textConstraints.maxHeight),
       density,
-      onClick,
     )
   }
 }
@@ -69,7 +64,6 @@ public class InlineContent(
   content: InlineContent,
   contentConstraints: Constraints,
   density: Density,
-  onClick: (() -> Unit)?,
 ): InlineTextContent {
   var size by remember {
     mutableStateOf(
@@ -88,19 +82,7 @@ public class InlineContent(
     )
 
     return InlineTextContent(placeholder) { alternateText ->
-      val wrappedContents = @Composable {
-        when (onClick) {
-          null -> content.content(density, alternateText)
-          else -> Box(
-            modifier = Modifier
-              .clickable(onClick = onClick)
-          ) {
-            content.content(density, alternateText)
-          }
-        }
-      }
-
-      Layout(content = wrappedContents) { measurables, _ ->
+      Layout(content = { content.content(density, alternateText) }) { measurables, _ ->
         // Measure the content with the constraints for the parent Text layout, not the actual.
         // This allows it to determine exactly how large it needs to be so we can update the
         // placeholder.

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -37,9 +37,12 @@ public fun RichTextScope.Text(
   val inlineContents = remember(text) { text.getInlineContents() }
 
   BoxWithConstraints(modifier = modifier) {
+    val inlineLink = annotated.getConsumableAnnotations(text.formatObjects, 0)
+      .firstOrNull()
     val inlineTextContents = manageInlineTextContents(
       inlineContents = inlineContents,
-      textConstraints = constraints
+      textConstraints = constraints,
+      onClick = if (inlineLink == null) null else {{ inlineLink.onClick() }}
     )
 
     ClickableText(
@@ -50,10 +53,10 @@ public fun RichTextScope.Text(
       overflow = overflow,
       maxLines = maxLines,
       isOffsetClickable = { offset ->
-        annotated.getConsumableAnnotations(text.formatObjects, offset).any()
+        annotated.getConsumableAnnotations(text.formatObjects, offset.coerceIn(0, annotated.length - 1)).any()
       },
       onClick = { offset ->
-        annotated.getConsumableAnnotations(text.formatObjects, offset)
+        annotated.getConsumableAnnotations(text.formatObjects, offset.coerceIn(0, annotated.length - 1))
           .firstOrNull()
           ?.let { link -> link.onClick() }
       }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -50,10 +50,17 @@ public fun RichTextScope.Text(
       overflow = overflow,
       maxLines = maxLines,
       isOffsetClickable = { offset ->
-        annotated.getConsumableAnnotations(text.formatObjects, offset.coerceIn(0, annotated.length - 1)).any()
+        // When you click past the end of the string, the offset is where the caret should be
+        // placed. However, when it is at the end, offset == text.length but parent links will at
+        // most end at length - 1. So we need to coerce the offset to be at most length - 1.
+        // This fixes an image where only the left side of an image wrapped with a link was only
+        // clickable on the left side.
+        // However, if a paragraph ends with a link, the link will be clickable past the
+        // end of the last line.
+        annotated.getConsumableAnnotations(text.formatObjects, offset.coerceAtMost(annotated.length - 1)).any()
       },
       onClick = { offset ->
-        annotated.getConsumableAnnotations(text.formatObjects, offset.coerceIn(0, annotated.length - 1))
+        annotated.getConsumableAnnotations(text.formatObjects, offset.coerceAtMost(annotated.length - 1))
           .firstOrNull()
           ?.let { link -> link.onClick() }
       }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -37,12 +37,9 @@ public fun RichTextScope.Text(
   val inlineContents = remember(text) { text.getInlineContents() }
 
   BoxWithConstraints(modifier = modifier) {
-    val inlineLink = annotated.getConsumableAnnotations(text.formatObjects, 0)
-      .firstOrNull()
     val inlineTextContents = manageInlineTextContents(
       inlineContents = inlineContents,
       textConstraints = constraints,
-      onClick = if (inlineLink == null) null else {{ inlineLink.onClick() }}
     )
 
     ClickableText(


### PR DESCRIPTION
I split out content override and inline content override for overriding inline and block content independently because they have slightly different rendering paths.

I also change the way images with links works. Check my PR comments for more info.