### PR TITLE
Add global animation timer

### DIFF
--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -2,7 +2,9 @@ package com.halilibo.richtext.markdown
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -38,6 +40,8 @@ import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.string.InlineContent
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.string.RichTextString
 import com.halilibo.richtext.ui.string.Text
 import com.halilibo.richtext.ui.string.richTextString
@@ -77,13 +81,13 @@ public typealias InlineContentOverride = RichTextScope.(
 public fun RichTextScope.Markdown(
   content: String,
   markdownParseOptions: MarkdownParseOptions = MarkdownParseOptions.Default,
-  markdownRenderOptions: MarkdownRenderOptions = MarkdownRenderOptions.Default,
+  richtextRenderOptions: RichTextRenderOptions = RichTextRenderOptions.Default,
   onLinkClicked: ((String) -> Unit)? = null,
   contentOverride: ContentOverride? = null,
   inlineContentOverride: InlineContentOverride? = null,
 ) {
   val markdown = parsedMarkdown(text = content, options = markdownParseOptions)
-  markdown?.let { Markdown(it, onLinkClicked, contentOverride, inlineContentOverride, markdownRenderOptions) }
+  markdown?.let { Markdown(it, onLinkClicked, contentOverride, inlineContentOverride, richtextRenderOptions) }
 }
 
 /**
@@ -98,7 +102,7 @@ public fun RichTextScope.Markdown(
   onLinkClicked: ((String) -> Unit)? = null,
   contentOverride: ContentOverride? = null,
   inlineContentOverride: InlineContentOverride? = null,
-  markdownRenderOptions: MarkdownRenderOptions = MarkdownRenderOptions.Default,
+  richtextRenderOptions: RichTextRenderOptions = RichTextRenderOptions.Default,
 ) {
   val onLinkClickedState = rememberUpdatedState(onLinkClicked)
   // Can't use UriHandlerAmbient.current::openUri here,
@@ -108,8 +112,15 @@ public fun RichTextScope.Markdown(
       { url -> it.openUri(url) }
     }
   }
+  val animationState = remember { mutableStateOf(MarkdownAnimationState()) }
   CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
-    RecursiveRenderMarkdownAst(content.toAstNode(), contentOverride, inlineContentOverride, markdownRenderOptions)
+    RecursiveRenderMarkdownAst(
+      content.toAstNode(),
+      contentOverride,
+      inlineContentOverride,
+      richtextRenderOptions,
+      animationState,
+    )
   }
 }
 
@@ -160,21 +171,41 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
   astNode: AstNode?,
   contentOverride: ContentOverride?,
   inlineContentOverride: InlineContentOverride?,
-  markdownRenderOptions: MarkdownRenderOptions,
+  richTextRenderOptions: RichTextRenderOptions,
+  markdownAnimationState: MutableState<MarkdownAnimationState>,
 ) {
   astNode ?: return
 
   if (contentOverride?.invoke(astNode) {
-      visitChildren(it, contentOverride, inlineContentOverride, markdownRenderOptions)
+      visitChildren(
+        it,
+        contentOverride,
+        inlineContentOverride,
+        richTextRenderOptions,
+        markdownAnimationState
+      )
     } == true) {
     return
   }
 
   when (val astNodeType = astNode.type) {
-    is AstDocument -> visitChildren(node = astNode, contentOverride, inlineContentOverride, markdownRenderOptions)
+    is AstDocument -> visitChildren(
+      node = astNode,
+      contentOverride,
+      inlineContentOverride,
+      richTextRenderOptions,
+      markdownAnimationState
+    )
+
     is AstBlockQuote -> {
       BlockQuote {
-        visitChildren(astNode, contentOverride, inlineContentOverride, markdownRenderOptions)
+        visitChildren(
+          astNode,
+          contentOverride,
+          inlineContentOverride,
+          richTextRenderOptions,
+          markdownAnimationState,
+        )
       }
     }
 
@@ -183,7 +214,13 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
         listType = Unordered,
         items = astNode.filterChildrenType<AstListItem>().toList()
       ) {
-        visitChildren(it, contentOverride, inlineContentOverride, markdownRenderOptions)
+        visitChildren(
+          it,
+          contentOverride,
+          inlineContentOverride,
+          richTextRenderOptions,
+          markdownAnimationState,
+        )
       }
     }
 
@@ -192,7 +229,13 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
         listType = Ordered,
         items = astNode.childrenSequence().toList()
       ) { astListItem ->
-        visitChildren(astListItem, contentOverride, inlineContentOverride, markdownRenderOptions)
+        visitChildren(
+          astListItem,
+          contentOverride,
+          inlineContentOverride,
+          richTextRenderOptions,
+          markdownAnimationState,
+        )
       }
     }
 
@@ -202,7 +245,13 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
 
     is AstHeading -> {
       Heading(level = astNodeType.level) {
-        MarkdownRichText(astNode, inlineContentOverride, markdownRenderOptions, Modifier.semantics { heading() })
+        MarkdownRichText(
+          astNode,
+          inlineContentOverride,
+          richTextRenderOptions,
+          markdownAnimationState,
+          Modifier.semantics { heading() },
+        )
       }
     }
 
@@ -228,11 +277,16 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
     }
 
     is AstParagraph -> {
-      MarkdownRichText(astNode, inlineContentOverride, markdownRenderOptions)
+      MarkdownRichText(
+        astNode,
+        inlineContentOverride,
+        richTextRenderOptions,
+        markdownAnimationState,
+      )
     }
 
     is AstTableRoot -> {
-      RenderTable(astNode, inlineContentOverride, markdownRenderOptions)
+      RenderTable(astNode, inlineContentOverride, richTextRenderOptions, markdownAnimationState)
     }
     // This should almost never happen. All the possible text
     // nodes must be under either Heading, Paragraph or CustomNode
@@ -272,14 +326,16 @@ internal fun RichTextScope.visitChildren(
   node: AstNode?,
   contentOverride: ContentOverride?,
   inlineContentOverride: InlineContentOverride?,
-  markdownRenderOptions: MarkdownRenderOptions,
+  richtextRenderOptions: RichTextRenderOptions,
+  markdownAnimationState: MutableState<MarkdownAnimationState>,
 ) {
   node?.childrenSequence()?.forEach {
     RecursiveRenderMarkdownAst(
       astNode = it,
       contentOverride,
       inlineContentOverride,
-      markdownRenderOptions,
+      richtextRenderOptions,
+      markdownAnimationState,
     )
   }
 }

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -39,6 +39,7 @@ import com.halilibo.richtext.ui.HorizontalRule
 import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
+import com.halilibo.richtext.ui.string.DefaultMarkdownAnimationState
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
@@ -112,7 +113,7 @@ public fun RichTextScope.Markdown(
       { url -> it.openUri(url) }
     }
   }
-  val animationState = remember { mutableStateOf(MarkdownAnimationState()) }
+  val animationState = remember { mutableStateOf(DefaultMarkdownAnimationState) }
   CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
     RecursiveRenderMarkdownAst(
       content.toAstNode(),

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -2,6 +2,7 @@ package com.halilibo.richtext.markdown
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -28,6 +29,8 @@ import com.halilibo.richtext.ui.BlockQuote
 import com.halilibo.richtext.ui.FormattedList
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.string.InlineContent
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.string.RichTextString
 import com.halilibo.richtext.ui.string.Text
 import com.halilibo.richtext.ui.string.withFormat
@@ -59,7 +62,8 @@ import com.halilibo.richtext.ui.string.withFormat
 internal fun RichTextScope.MarkdownRichText(
   astNode: AstNode,
   inlineContentOverride: InlineContentOverride?,
-  markdownRenderOptions: MarkdownRenderOptions,
+  richTextRenderOptions: RichTextRenderOptions,
+  markdownAnimationState: MutableState<MarkdownAnimationState>,
   modifier: Modifier = Modifier,
 ) {
   val onLinkClicked = LocalOnLinkClicked.current
@@ -72,10 +76,8 @@ internal fun RichTextScope.MarkdownRichText(
     text = richText,
     modifier = modifier,
     isLeafText = astNode.links.next == null && astNode.links.parent?.links?.next == null,
-    animate = markdownRenderOptions.animate,
-    textFadeInMs = markdownRenderOptions.textFadeInMs,
-    debounceMs = markdownRenderOptions.debounceMs,
-    delayMs = markdownRenderOptions.delayMs,
+    renderOptions = richTextRenderOptions,
+    sharedAnimationState = markdownAnimationState,
   )
 }
 

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -1,6 +1,7 @@
 package com.halilibo.richtext.markdown
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import com.halilibo.richtext.markdown.node.AstNode
 import com.halilibo.richtext.markdown.node.AstTableBody
 import com.halilibo.richtext.markdown.node.AstTableCell
@@ -8,12 +9,15 @@ import com.halilibo.richtext.markdown.node.AstTableHeader
 import com.halilibo.richtext.markdown.node.AstTableRow
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.Table
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
 @Composable
 internal fun RichTextScope.RenderTable(
   node: AstNode,
   inlineContentOverride: InlineContentOverride?,
-  markdownRenderOptions: MarkdownRenderOptions,
+  richtextRenderOptions: RichTextRenderOptions,
+  markdownAnimationState: MutableState<MarkdownAnimationState>,
 ) {
   Table(
     headerRow = {
@@ -24,7 +28,12 @@ internal fun RichTextScope.RenderTable(
         ?.filterChildrenType<AstTableCell>()
         ?.forEach { tableCell ->
           cell {
-            MarkdownRichText(tableCell, inlineContentOverride, markdownRenderOptions)
+            MarkdownRichText(
+              tableCell,
+              inlineContentOverride,
+              richtextRenderOptions,
+              markdownAnimationState,
+            )
           }
         }
     }
@@ -37,7 +46,12 @@ internal fun RichTextScope.RenderTable(
           tableRow.filterChildrenType<AstTableCell>()
             .forEach { tableCell ->
               cell {
-                MarkdownRichText(tableCell, inlineContentOverride, markdownRenderOptions)
+                MarkdownRichText(
+                  tableCell,
+                  inlineContentOverride,
+                  richtextRenderOptions,
+                  markdownAnimationState,
+                )
               }
             }
         }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
@@ -1,15 +1,16 @@
-package com.halilibo.richtext.markdown
+package com.halilibo.richtext.ui.string
 
 /**
  * Allows configuration of the Markdown renderer
  */
-public data class MarkdownRenderOptions(
+public data class RichTextRenderOptions(
   val animate: Boolean = false,
   val textFadeInMs: Int = 600,
   val debounceMs: Int = 100050,
   val delayMs: Int = 10,
+  val onTextAnimate: () -> Unit = {},
 ) {
   public companion object {
-    public val Default: MarkdownRenderOptions = MarkdownRenderOptions()
+    public val Default: RichTextRenderOptions = RichTextRenderOptions()
   }
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -48,7 +48,7 @@ public fun RichTextScope.Text(
   isLeafText: Boolean = true,
   renderOptions: RichTextRenderOptions = RichTextRenderOptions(),
   sharedAnimationState: MutableState<MarkdownAnimationState> =
-    mutableStateOf(MarkdownAnimationState()),
+    mutableIntStateOf(DefaultMarkdownAnimationState),
   overflow: TextOverflow = TextOverflow.Clip,
   maxLines: Int = Int.MAX_VALUE
 ) {
@@ -100,14 +100,13 @@ public fun RichTextScope.Text(
   }
 }
 
-public data class MarkdownAnimationState(
-  val totalOffset: Int = 0,
-){
-  public fun addAnimation(): MarkdownAnimationState = copy(totalOffset = totalOffset + 1)
-  public fun removeAnimation(): MarkdownAnimationState = copy(totalOffset = totalOffset - 1)
-  public fun toDelayMs(defaultDelayMs: Int): Int =
-    (sqrt(totalOffset.toDouble()) * defaultDelayMs).toInt()
-}
+public typealias MarkdownAnimationState = Int
+// Add a default value
+public val DefaultMarkdownAnimationState: MarkdownAnimationState = 0
+private fun MarkdownAnimationState.addAnimation(): MarkdownAnimationState = this + 1
+private fun MarkdownAnimationState.removeAnimation(): MarkdownAnimationState = this - 1
+private fun MarkdownAnimationState.toDelayMs(defaultDelayMs: Int): Int =
+  (sqrt(this.toDouble()) * defaultDelayMs).toInt()
 
 @Composable
 @OptIn(FlowPreview::class)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -30,6 +31,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
+import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -44,10 +46,9 @@ public fun RichTextScope.Text(
   onTextLayout: (TextLayoutResult) -> Unit = {},
   softWrap: Boolean = true,
   isLeafText: Boolean = true,
-  animate: Boolean = false,
-  textFadeInMs: Int = 400,
-  debounceMs: Int = 200,
-  delayMs: Int = 100,
+  renderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+  sharedAnimationState: MutableState<MarkdownAnimationState> =
+    mutableStateOf(MarkdownAnimationState()),
   overflow: TextOverflow = TextOverflow.Clip,
   maxLines: Int = Int.MAX_VALUE
 ) {
@@ -60,13 +61,11 @@ public fun RichTextScope.Text(
   val inlineContents = remember(text) { text.getInlineContents() }
 
   val animatedText = rememberAnimatedText(
-    animate = animate,
     annotated = annotated,
     contentColor = contentColor,
-    debounceMs = debounceMs,
-    textFadeInMs = textFadeInMs,
+    renderOptions = renderOptions,
     isLeafText = isLeafText,
-    delayMs = delayMs,
+    sharedAnimationState = sharedAnimationState,
     hasInlineTextContent = inlineContents.isNotEmpty(),
   )
 
@@ -101,28 +100,36 @@ public fun RichTextScope.Text(
   }
 }
 
+public data class MarkdownAnimationState(
+  val totalOffset: Int = 0,
+){
+  public fun addAnimation(): MarkdownAnimationState = copy(totalOffset = totalOffset + 1)
+  public fun removeAnimation(): MarkdownAnimationState = copy(totalOffset = totalOffset - 1)
+  public fun toDelayMs(defaultDelayMs: Int): Int =
+    (sqrt(totalOffset.toDouble()) * defaultDelayMs).toInt()
+}
+
 @Composable
 @OptIn(FlowPreview::class)
 private fun rememberAnimatedText(
-  animate: Boolean,
   annotated: AnnotatedString,
+  renderOptions: RichTextRenderOptions,
   contentColor: Color,
-  debounceMs: Int,
-  textFadeInMs: Int,
-  delayMs: Int,
+  sharedAnimationState: MutableState<MarkdownAnimationState>,
   isLeafText: Boolean,
   hasInlineTextContent: Boolean,
 ): AnnotatedString {
   val coroutineScope = rememberCoroutineScope()
   val animations = remember { mutableStateMapOf<Int, TextAnimation>() }
   val textToRender = remember { mutableStateOf(AnnotatedString("")) }
-  if (animate) {
+  if (renderOptions.animate) {
     val lastAnimationIndex = remember { mutableIntStateOf(-1) }
     val readyToAnimateText = remember { mutableStateOf(PhraseAnnotatedString()) }
     // In case no changes happen for a while, we'll render after some timeout
     val debouncedTextFlow = remember { MutableStateFlow(AnnotatedString("")) }
-    val debouncedText by remember { debouncedTextFlow.debounce(debounceMs.milliseconds) }
-      .collectAsState(AnnotatedString(""), coroutineScope.coroutineContext)
+    val debouncedText by remember {
+      debouncedTextFlow.debounce(renderOptions.debounceMs.milliseconds)
+    }.collectAsState(AnnotatedString(""), coroutineScope.coroutineContext)
 
     LaunchedEffect(annotated) {
       debouncedTextFlow.value = annotated
@@ -152,15 +159,18 @@ private fun rememberAnimatedText(
           lastAnimationIndex.value = phraseIndex
           coroutineScope.launch {
             textToRender.value = readyToAnimateText.value.makeCompletePhraseString(!isLeafText)
+            sharedAnimationState.value = sharedAnimationState.value.addAnimation()
             Animatable(0f).animateTo(
               targetValue = 1f,
               animationSpec = tween(
-                durationMillis = textFadeInMs,
-                delayMillis = (animations.size * delayMs).coerceAtMost(2000),
+                durationMillis = renderOptions.textFadeInMs,
+                delayMillis = sharedAnimationState.value.toDelayMs(renderOptions.delayMs),
               )
             ) {
               animations[phraseIndex] = TextAnimation(phraseIndex, value)
+              renderOptions.onTextAnimate()
             }
+            sharedAnimationState.value = sharedAnimationState.value.removeAnimation()
             animations.remove(phraseIndex)
           }
         }
@@ -182,9 +192,10 @@ private fun rememberAnimatedText(
   }
 }
 
-private data class TextAnimation(val startIndex: Int, val alpha: Float)
+private data class TextAnimation(val startIndex: Int, val alpha: Float) 
 
-private fun AnnotatedString.animateAlphas(animations: Collection<TextAnimation>, contentColor: Color): AnnotatedString {
+private fun AnnotatedString.animateAlphas(
+  animations: Collection<TextAnimation>, contentColor: Color): AnnotatedString {
   if (this.text.isEmpty() || animations.isEmpty()) {
     return this
   }


### PR DESCRIPTION
Passes through a MutableState<MarkdownAnimationState> starting from the root Markdown node makes this all nice and synchronized. Honestly I thought it'd be more work than this.