### PR TITLE
Add word-based animation instead of 'phrase based'

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -260,7 +260,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     targetAlpha.value,
     tween(
       richTextRenderOptions.textFadeInMs,
-      delayMillis = markdownAnimationState.value.toDelayMs(richTextRenderOptions.delayMs),
+      delayMillis = markdownAnimationState.value.toDelayMs(richTextRenderOptions),
     )
   )
   return alpha

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
@@ -8,6 +8,9 @@ public data class RichTextRenderOptions(
   val textFadeInMs: Int = 500,
   val debounceMs: Int = 100050,
   val delayMs: Int = 70,
+  val delayExponent: Double = 0.7,
+  val maxPhraseLength: Int = 30,
+  val phraseMarkersOverride: List<Char>? = null,
   val onTextAnimate: () -> Unit = {},
 ) {
   public companion object {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
@@ -5,9 +5,9 @@ package com.halilibo.richtext.ui.string
  */
 public data class RichTextRenderOptions(
   val animate: Boolean = false,
-  val textFadeInMs: Int = 600,
+  val textFadeInMs: Int = 500,
   val debounceMs: Int = 100050,
-  val delayMs: Int = 10,
+  val delayMs: Int = 70,
   val onTextAnimate: () -> Unit = {},
 ) {
   public companion object {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
+import kotlin.math.pow
 import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -106,7 +107,7 @@ public val DefaultMarkdownAnimationState: MarkdownAnimationState = 0
 private fun MarkdownAnimationState.addAnimation(): MarkdownAnimationState = this + 1
 private fun MarkdownAnimationState.removeAnimation(): MarkdownAnimationState = this - 1
 public fun MarkdownAnimationState.toDelayMs(defaultDelayMs: Int): Int =
-  (sqrt(this.toDouble()) * defaultDelayMs).toInt()
+  (this.toDouble().pow(0.7) * defaultDelayMs).toInt()
 
 @Composable
 @OptIn(FlowPreview::class)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -106,8 +106,8 @@ public typealias MarkdownAnimationState = Int
 public val DefaultMarkdownAnimationState: MarkdownAnimationState = 0
 private fun MarkdownAnimationState.addAnimation(): MarkdownAnimationState = this + 1
 private fun MarkdownAnimationState.removeAnimation(): MarkdownAnimationState = this - 1
-public fun MarkdownAnimationState.toDelayMs(defaultDelayMs: Int): Int =
-  (this.toDouble().pow(0.7) * defaultDelayMs).toInt()
+public fun MarkdownAnimationState.toDelayMs(renderOptions: RichTextRenderOptions): Int =
+  (this.toDouble().pow(renderOptions.delayExponent) * renderOptions.delayMs).toInt()
 
 @Composable
 @OptIn(FlowPreview::class)
@@ -134,19 +134,20 @@ private fun rememberAnimatedText(
     LaunchedEffect(annotated) {
       debouncedTextFlow.value = annotated
       // If we detect a new phrase, kick off the animation now.
-      val phrases = annotated.segmentIntoPhrases(isComplete = !isLeafText)
+      val phrases = annotated.segmentIntoPhrases(renderOptions, isComplete = !isLeafText)
       if (phrases.hasNewPhrasesFrom(readyToAnimateText.value)) {
         readyToAnimateText.value = phrases
       }
     }
     LaunchedEffect(isLeafText, annotated) {
       if (!isLeafText) {
-        readyToAnimateText.value = annotated.segmentIntoPhrases(isComplete = true)
+        readyToAnimateText.value = annotated.segmentIntoPhrases(renderOptions, isComplete = true)
       }
     }
     LaunchedEffect(debouncedText) {
       if (debouncedText.text.isNotEmpty()) {
-        readyToAnimateText.value = debouncedText.segmentIntoPhrases(isComplete = true)
+        readyToAnimateText.value =
+          debouncedText.segmentIntoPhrases(renderOptions, isComplete = true)
       }
     }
 
@@ -164,7 +165,7 @@ private fun rememberAnimatedText(
               targetValue = 1f,
               animationSpec = tween(
                 durationMillis = renderOptions.textFadeInMs,
-                delayMillis = sharedAnimationState.value.toDelayMs(renderOptions.delayMs),
+                delayMillis = sharedAnimationState.value.toDelayMs(renderOptions),
               )
             ) {
               animations[phraseIndex] = TextAnimation(phraseIndex, value)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/util/AnnotatedStringSegmenter.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/util/AnnotatedStringSegmenter.kt
@@ -54,6 +54,7 @@ private fun AnnotatedString.stylePhrases(): List<String> {
 }
 
 private val phraseMarkers = listOf(
+  ' ',    // Space
   '.',    // Period
   '!',    // Exclamation mark
   '?',    // Question mark
@@ -87,4 +88,4 @@ private val phraseMarkers = listOf(
   '፨'     // Ethiopic paragraph separator
 )
 
-private const val MAX_PHRASE_LENGTH = 50
+private const val MAX_PHRASE_LENGTH = 30

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/util/AnnotatedStringSegmenter.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/util/AnnotatedStringSegmenter.kt
@@ -1,6 +1,7 @@
 package com.halilibo.richtext.ui.util
 
 import androidx.compose.ui.text.AnnotatedString
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
 public data class PhraseAnnotatedString(
   val annotatedString: AnnotatedString = AnnotatedString(""),
@@ -21,16 +22,20 @@ public data class PhraseAnnotatedString(
   }
 }
 
-public fun AnnotatedString.segmentIntoPhrases(isComplete: Boolean = false): PhraseAnnotatedString {
+public fun AnnotatedString.segmentIntoPhrases(
+  renderOptions: RichTextRenderOptions,
+  isComplete: Boolean = false,
+): PhraseAnnotatedString {
   val stylePhrases = stylePhrases()
+  val phraseMarkers = renderOptions.phraseMarkersOverride ?: phraseMarkers
   val phrases = stylePhrases
     .map { it.split(delimiters = phraseMarkers.toCharArray(), ignoreCase = false) }
     .flatten()
   val phraseSegments = mutableListOf(0)
   for (phrase in phrases) {
     if (phrase != phrases.last()) {
-      if (phrase.length > MAX_PHRASE_LENGTH * 1.2) {
-        phraseSegments.add(phraseSegments.last() + MAX_PHRASE_LENGTH)
+      if (phrase.length > renderOptions.maxPhraseLength * 1.2) {
+        phraseSegments.add(phraseSegments.last() + renderOptions.maxPhraseLength)
       }
       phraseSegments.add(text.length.coerceAtMost(phraseSegments.last() + phrase.length + 1))
     }
@@ -87,5 +92,3 @@ private val phraseMarkers = listOf(
   '፧',    // Ethiopic question mark
   '፨'     // Ethiopic paragraph separator
 )
-
-private const val MAX_PHRASE_LENGTH = 30


### PR DESCRIPTION
[Screen_recording_20240912_151152.webm](https://github.com/user-attachments/assets/24ebe509-6b1c-447f-992f-ec541a5b3571)


This is the new spec for smooth token streaming