### PR TITLE
Smoother animations

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -38,7 +38,6 @@ import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.string.DefaultMarkdownAnimationState
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
-import com.halilibo.richtext.ui.string.toDelayMs
 import kotlinx.coroutines.delay
 import kotlin.math.max
 
@@ -211,7 +210,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
  */
 @Composable public fun <T> RichTextScope.FormattedList(
   listType: ListType,
-  markdownAnimationState: MutableState<MarkdownAnimationState> = mutableIntStateOf(
+  markdownAnimationState: MutableState<MarkdownAnimationState> = mutableStateOf(
     DefaultMarkdownAnimationState),
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
   items: List<T>,
@@ -260,7 +259,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     targetAlpha.value,
     tween(
       richTextRenderOptions.textFadeInMs,
-      delayMillis = markdownAnimationState.value.toDelayMs(richTextRenderOptions),
+      delayMillis = markdownAnimationState.value.toDelayMs(),
     )
   )
   return alpha

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
+import kotlin.math.pow
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -113,8 +114,7 @@ public data class MarkdownAnimationState(
       val diffMs = lastAnimationStartMs - now
       when {
         diffMs < renderOptions.delayMs -> renderOptions.delayMs - diffMs
-        else -> diffMs + (renderOptions.delayMs * Math.pow(
-          (renderOptions.delayMs / diffMs.toDouble()),
+        else -> diffMs + (renderOptions.delayMs * (renderOptions.delayMs / diffMs.toDouble()).pow(
           renderOptions.delayExponent
         )).toLong()
       }
@@ -248,7 +248,10 @@ private fun AnnotatedString.changeAlpha(alpha: Float, contentColor: Color): Anno
 }
 
 
-private fun AnnotatedString.getConsumableAnnotations(textFormatObjects: Map<String, Any>, offset: Int): Sequence<Format.Link> =
+private fun AnnotatedString.getConsumableAnnotations(
+  textFormatObjects: Map<String, Any>,
+  offset: Int,
+): Sequence<Format.Link> =
   getStringAnnotations(Format.FormatAnnotationScope, offset, offset)
     .asSequence()
     .mapNotNull {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -186,29 +186,24 @@ private fun rememberAnimatedText(
       debouncedTextFlow.value = annotated
       // If we detect a new phrase, kick off the animation now.
       val phrases = annotated.segmentIntoPhrases(renderOptions, isComplete = !isLeafText)
-      if (phrases.hasNewPhrasesFrom(readyToAnimateText.value)) {
-        if (phrases != readyToAnimateText.value) {
-          readyToAnimateText.value = phrases
-          animationUpdate()
-        }
-      }
+      if (phrases.hasNewPhrasesFrom(readyToAnimateText.value).not()) return@LaunchedEffect
+      readyToAnimateText.value = phrases
+      animationUpdate()
     }
     LaunchedEffect(isLeafText, annotated) {
-      if (!isLeafText) {
-        val phrases = annotated.segmentIntoPhrases(renderOptions, isComplete = true)
-        if (phrases != readyToAnimateText.value) {
-          readyToAnimateText.value = phrases
-          animationUpdate()
-        }
+      if (isLeafText) return@LaunchedEffect
+      val phrases = annotated.segmentIntoPhrases(renderOptions, isComplete = true)
+      if (phrases != readyToAnimateText.value) {
+        readyToAnimateText.value = phrases
+        animationUpdate()
       }
     }
     LaunchedEffect(debouncedText) {
-      if (debouncedText.text.isNotEmpty()) {
-        val phrases = debouncedText.segmentIntoPhrases(renderOptions, isComplete = true)
-        if (phrases != readyToAnimateText.value) {
-          readyToAnimateText.value = phrases
-            animationUpdate()
-        }
+      if (debouncedText.text.isEmpty()) return@LaunchedEffect
+      val phrases = debouncedText.segmentIntoPhrases(renderOptions, isComplete = true)
+      if (phrases != readyToAnimateText.value) {
+        readyToAnimateText.value = phrases
+          animationUpdate()
       }
     }
 


### PR DESCRIPTION
I'm doing away with animationCount and instead remembering the timestamp of when the last animation _should_ kick of. This means if we add elements in waves, they'll naturally all smooth out. Also, removing the secondary LaunchedEffect because I tracked it down as the cause of reordering bugs