### PR TITLE
Fix deprecation warnings

### DIFF
--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -175,7 +175,7 @@ private fun RichTextScope.computeRichTextString(
         )
       }
 
-      iteratorStack = iteratorStack.addFirst(
+      iteratorStack = iteratorStack.addFirstInternal(
         AstNodeTraversalEntry(
           astNode = currentNode,
           isVisited = true,
@@ -186,7 +186,7 @@ private fun RichTextScope.computeRichTextString(
       // Do not visit children of terminals such as Text, Image, etc.
       if (!currentNode.isRichTextTerminal()) {
         currentNode.childrenSequence(reverse = true).forEach {
-          iteratorStack = iteratorStack.addFirst(
+          iteratorStack = iteratorStack.addFirstInternal(
             AstNodeTraversalEntry(
               astNode = it,
               isVisited = false,
@@ -211,6 +211,6 @@ private data class AstNodeTraversalEntry(
   val formatIndex: Int?
 )
 
-private inline fun <reified T> List<T>.addFirst(item: T): List<T> {
+private inline fun <reified T> List<T>.addFirstInternal(item: T): List<T> {
   return listOf(item) + this
 }

--- a/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -51,6 +51,7 @@ private fun toByteArray(bitmap: BufferedImage): ByteArray {
 
 private suspend fun loadFullImage(source: String): BufferedImage? = withContext(Dispatchers.IO) {
   runCatching {
+    @Suppress("DEPRECATION")
     val url = URL(source)
     val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
     connection.connectTimeout = 5000


### PR DESCRIPTION
These don't show up in Android Studio but if you try to publish to maven, the build will fail with these warnings.

The `addFirst` one is strange, it fails with:
```
e: file:///Users/gabriel/repos/compose-richtext/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt:178:23 Type mismatch: inferred type is Unit but List<AstNodeTraversalEntry> was expected
e: file:///Users/gabriel/repos/compose-richtext/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt:189:27 Type mismatch: inferred type is Unit but List<AstNodeTraversalEntry> was expected
```

It is almost like it's conflicting with a stdlib function but I don't think it is.