### PR TITLE
Expose tag and annotated string

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
@@ -291,9 +291,9 @@ public data class RichTextString internal constructor(
 
     public fun appendInlineContent(
       alternateText: String = REPLACEMENT_CHAR,
+      tag: String = randomUUID(),
       content: InlineContent
     ) {
-      val tag = randomUUID()
       formatObjects["inline:$tag"] = content
 
       // Resets the style to defaults.


### PR DESCRIPTION
These are the next steps to get animated inline content to work:
1. Exposing tag is necessary so if the text content changes, the app can provide a stable tag for the inline composable. This is important for composables that may not render their final UI in the first pass like a remote image
2. It is necessary to copy paragraph styles and string annotations in order for the inline content to be reified