### PR TITLE
Filter empty string annotations when creating an alpha AnnotatedString

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -260,7 +260,7 @@ private fun AnnotatedString.changeAlpha(alpha: Float, contentColor: Color): Anno
   return buildAnnotatedString {
     append(text)
     newWordsStyles.forEach { addStyle(it.item, it.start, it.end) }
-    stringAnnotations.forEach { addStringAnnotation(it.tag, it.item, it.start, it.end) }
+    stringAnnotations.filter { it.end > it.start }.forEach { addStringAnnotation(it.tag, it.item, it.start, it.end) }
     paragraphStyles.forEach { addStyle(it.item, it.start, it.end) }
   }
 }


### PR DESCRIPTION
This is an attempt to fix:

```
java.lang.IllegalStateException: PlaceholderSpan is not laid out yet.
    at androidx.compose.ui.text.android.style.PlaceholderSpan.getWidthPx(PlaceholderSpan.android.kt:96)
    at androidx.compose.ui.text.AndroidParagraph.<init>(AndroidParagraph.android.kt:277)
    at androidx.compose.ui.text.AndroidParagraph.<init>(AndroidParagraph.android.kt:0)
    at androidx.compose.ui.text.platform.AndroidParagraph_androidKt.ActualParagraph--hBUhpc
    at androidx.compose.ui.text.ParagraphKt.Paragraph-_EkL_-Y
    at androidx.compose.ui.text.MultiParagraph.<init>(MultiParagraph.kt:325)
    at androidx.compose.ui.text.MultiParagraph.<init>(MultiParagraph.kt:0)
    at androidx.compose.foundation.text.modifiers.MultiParagraphLayoutCache.layoutText-K40F9xA(MultiParagraphLayoutCache.kt:279)
    at androidx.compose.foundation.text.modifiers.MultiParagraphLayoutCache.layoutWithConstraints-K40F9xA
    at androidx.compose.foundation.text.modifiers.TextAnnotatedStringNode.measure-3p2s80s(TextAnnotatedStringNode.kt:423)
    at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:188)
```