### PR TITLE
Avoid placeholderspan crashes for inline content by not introducing extra spans

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -235,9 +235,8 @@ private fun AnnotatedString.animateAlphas(
   val inlineContentSpans = getStringAnnotations(0, length)
     .filter { it.tag == "androidx.compose.foundation.text.inlineContent" }
   val inlineContentStyles = spanStyles.filter { it.tag == "androidx.compose.foundation.text.inlineContent"}
-  val inlineSpansToWatchOutFor = inlineContentSpans + inlineContentStyles
   // Chopping up a string with inline content in it causes a crash. So we need to fade in the entire block.
-  if (inlineSpansToWatchOutFor.isNotEmpty()) {
+  if (inlineContentSpans.isNotEmpty() || inlineContentStyles.isNotEmpty()) {
     return remainingText.changeAlpha(animations.first().alpha, contentColor)
   }
   animations.sortedByDescending { it.startIndex }.forEach { animation ->


### PR DESCRIPTION
it turns out animating inlineContent reliably crashes, pretty much no matter how we animate it. This at least keeps the span animating with the overall UI (including the cross-markdown-element delay), but doesn't chop the string up further.