### PR TITLE
Fix table cell size crash

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/SimpleTableLayout.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/SimpleTableLayout.kt
@@ -52,7 +52,7 @@ internal fun SimpleTableLayout(
     check(constraints.hasBoundedWidth) { "Table must have bounded width" }
     // Divide the width by the number of columns, then leave room for the padding.
     val cellSpacingWidth = cellSpacing * (columns + 1)
-    val cellWidth = (constraints.maxWidth - cellSpacingWidth) / columns
+    val cellWidth = minOf((constraints.maxWidth - cellSpacingWidth) / columns, MinCellWidth)
     val cellSpacingHeight = cellSpacing * (rowMeasurables.size + 1)
     // TODO Handle bounded height constraints.
     // val cellMaxHeight = if (!constraints.hasBoundedHeight) {
@@ -109,3 +109,5 @@ internal fun SimpleTableLayout(
     }
   }
 }
+
+private const val MinCellWidth = 10f


### PR DESCRIPTION
Fix the following crash. What happens is that if we have very limited space and a large number of columns, we can get negative values for the cell width constraint. This should fix it by setting a minimum width. It probably won't look great, but at least we won't crash the app and the rest of the content should be rendered just fine.
```
Exception java.lang.IllegalArgumentException: maxWidth(-1) must be >= than minWidth(0)
  at androidx.compose.ui.unit.InlineClassHelperKt.throwIllegalArgumentException (InlineClassHelper.kt:30)
  at androidx.compose.ui.unit.ConstraintsKt.Constraints (Constraints.kt:721)
  at androidx.compose.ui.unit.ConstraintsKt.Constraints$default (Constraints.kt:543)
  at com.halilibo.richtext.ui.SimpleTableLayoutKt$SimpleTableLayout$1.invoke-0kLqBqw (SimpleTableLayout.kt:64)
  at com.halilibo.richtext.ui.SimpleTableLayoutKt$SimpleTableLayout$1.invoke (SimpleTableLayout.kt:39)
  at androidx.compose.ui.layout.LayoutNodeSubcompositionsState$createMeasurePolicy$1.measure-3p2s80s (SubcomposeLayout.kt:725)
  at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0 (InnerNodeCoordinator.kt:135)
  ...
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```