### PR TITLE
Deferred alpha animation reads + fixes and dep updates

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/AnimationSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/AnimationSample.kt
@@ -1,0 +1,138 @@
+package com.zachklipp.richtext.sample
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.MaterialTheme.colors
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
+import kotlinx.coroutines.delay
+import kotlin.random.Random
+
+@Preview
+@Composable private fun AnimatedRichTextSamplePreview() {
+  AnimatedRichTextSample()
+}
+
+@Composable fun AnimatedRichTextSample() {
+  var isChunked by remember { mutableStateOf(false) }
+
+  MaterialTheme(colors = colors) {
+    Surface {
+      Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+          Text(
+            "Chunking",
+            modifier = Modifier
+              .weight(1f)
+              .padding(16.dp),
+          )
+          Checkbox(isChunked, onCheckedChange = { isChunked = it })
+        }
+        Box(Modifier.verticalScroll(rememberScrollState()).padding(16.dp)) {
+          if (!isChunked) {
+            CompleteTextSample()
+          } else {
+            ChunkingTextSample()
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun CompleteTextSample() {
+  val markdownOptions = remember {
+    RichTextRenderOptions(
+      animate = true,
+      textFadeInMs = 500,
+      delayMs = 70,
+      debounceMs = 200,
+    )
+  }
+
+  RichText {
+    Markdown(
+      SampleText,
+      richtextRenderOptions = markdownOptions,
+    )
+  }
+}
+
+@Composable
+private fun ChunkingTextSample() {
+  var currentText by remember { mutableStateOf("") }
+  var isComplete by remember { mutableStateOf(false) }
+
+  LaunchedEffect(Unit) {
+    var remaining = SampleText
+    while (remaining.isNotEmpty()) {
+      delay(200L + Random.nextInt(500))
+      val chunkLength = 10 + Random.nextInt(100)
+      currentText += remaining.take(chunkLength)
+      remaining = remaining.drop(chunkLength)
+    }
+    isComplete = true
+  }
+
+  val markdownOptions = remember(isComplete) {
+    RichTextRenderOptions(
+      animate = !isComplete,
+      textFadeInMs = 500,
+      delayMs = 70,
+      debounceMs = 200,
+    )
+  }
+
+  RichText {
+    Markdown(
+      currentText,
+      richtextRenderOptions = markdownOptions,
+    )
+  }
+}
+
+private const val SampleText = """
+1-The quick brown fox jumps over the lazy dog.
+1-The quick brown fox jumps over the lazy dog.
+1-The quick brown fox jumps over the lazy dog.
+1-The quick brown fox jumps over the lazy dog.
+1-The quick brown fox jumps over the lazy dog.
+
+* Formatted list 1
+* Formatted list 2
+  * Sub bullet point
+
+# Header 1
+2-The quick brown fox jumps over the lazy dog.
+The quick brown fox jumps over the lazy dog.
+
+| Column A | Column B |
+|----------|----------|
+| The quick brown fox jumps over the lazy dog. | The quick brown fox jumps over the lazy dog. |
+
+##### Header 5
+4-The quick brown fox jumps over the lazy dog.
+The quick brown fox jumps over the lazy dog.
+The quick brown fox jumps over the lazy dog.
+The quick brown fox **jumps over the lazy dog.**
+"""

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -35,6 +35,7 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   "Pagination" to @Composable { PagedSample() },
   "Printable Document" to @Composable { DocumentSample() },
   "Slideshow" to @Composable { SlideshowSample() },
+  "Text Animation" to @Composable { AnimatedRichTextSample() },
 )
 
 @Preview(showBackground = true)

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/ScreenPreview.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/ScreenPreview.kt
@@ -64,17 +64,9 @@ import androidx.compose.ui.unit.IntSize
     val previewDensityScale = constraints.maxWidth / screenSize.width.toFloat()
     val previewDensity = actualDensity * previewDensityScale
 
-    // Provide a fake host view, since the preview doesn't really belong to this host view.
-    val context = LocalContext.current
-    val previewView = remember {
-      val previewContext = context.applicationContext
-      FrameLayout(previewContext)
-    }
-
     DisableSelection {
       CompositionLocalProvider(
         LocalDensity provides Density(previewDensity),
-        LocalView provides previewView,
         content = content
       )
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,9 +4,9 @@ object BuildPlugins {
 }
 
 object AndroidX {
-  val activity = "androidx.activity:activity:1.5.0-rc01"
+  val activity = "androidx.activity:activity:1.9.1"
   val annotations = "androidx.annotation:annotation:1.1.0"
-  val appcompat = "androidx.appcompat:appcompat:1.3.0"
+  val appcompat = "androidx.appcompat:appcompat:1.7.0"
   val material = "com.google.android.material:material:1.1.0"
 }
 
@@ -30,14 +30,14 @@ object Kotlin {
 val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
 
 object Compose {
-  val version = "1.5.4"
-  val compilerVersion = "1.5.4"
+  val version = "1.7.8"
+  val compilerVersion = "1.5.5"
   val desktopVersion = "1.5.11"
-  val activity = "androidx.activity:activity-compose:1.7.2"
+  val activity = "androidx.activity:activity-compose:1.9.1"
   val foundation = "androidx.compose.foundation:foundation:$version"
   val material = "androidx.compose.material:material:$version"
-  val material3 = "androidx.compose.material3:material3:1.0.1"
-  val icons = "androidx.compose.material:material-icons-extended:$version"
+  val material3 = "androidx.compose.material3:material3:1.3.1"
+  val icons = "androidx.compose.material:material-icons-extended:1.7.8"
   val test = "androidx.ui:ui-test:$version"
   val tooling = "androidx.compose.ui:ui-tooling:$version"
   val toolingData = "androidx.compose.ui:ui-tooling-data:$version"

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -39,7 +39,6 @@ import com.halilibo.richtext.ui.HorizontalRule
 import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
-import com.halilibo.richtext.ui.string.DefaultMarkdownAnimationState
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
@@ -113,7 +112,7 @@ public fun RichTextScope.Markdown(
       { url -> it.openUri(url) }
     }
   }
-  val animationState = remember { mutableStateOf(DefaultMarkdownAnimationState) }
+  val animationState = remember { MarkdownAnimationState() }
   CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
     RecursiveRenderMarkdownAst(
       content.toAstNode(),
@@ -173,7 +172,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
   contentOverride: ContentOverride?,
   inlineContentOverride: InlineContentOverride?,
   richTextRenderOptions: RichTextRenderOptions,
-  markdownAnimationState: MutableState<MarkdownAnimationState>,
+  markdownAnimationState: MarkdownAnimationState,
 ) {
   astNode ?: return
 
@@ -332,7 +331,7 @@ internal fun RichTextScope.visitChildren(
   contentOverride: ContentOverride?,
   inlineContentOverride: InlineContentOverride?,
   richtextRenderOptions: RichTextRenderOptions,
-  markdownAnimationState: MutableState<MarkdownAnimationState>,
+  markdownAnimationState: MarkdownAnimationState,
 ) {
   node?.childrenSequence()?.forEach {
     RecursiveRenderMarkdownAst(

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -63,7 +63,7 @@ internal fun RichTextScope.MarkdownRichText(
   astNode: AstNode,
   inlineContentOverride: InlineContentOverride?,
   richTextRenderOptions: RichTextRenderOptions,
-  markdownAnimationState: MutableState<MarkdownAnimationState>,
+  markdownAnimationState: MarkdownAnimationState,
   modifier: Modifier = Modifier,
 ) {
   val onLinkClicked = LocalOnLinkClicked.current

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -17,7 +17,7 @@ internal fun RichTextScope.RenderTable(
   node: AstNode,
   inlineContentOverride: InlineContentOverride?,
   richtextRenderOptions: RichTextRenderOptions,
-  markdownAnimationState: MutableState<MarkdownAnimationState>,
+  markdownAnimationState: MarkdownAnimationState,
 ) {
   Table(
     headerRow = {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -2,10 +2,8 @@
 
 package com.halilibo.richtext.ui
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
@@ -14,12 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,10 +30,8 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
-import com.halilibo.richtext.ui.string.DefaultMarkdownAnimationState
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
-import kotlinx.coroutines.delay
 import kotlin.math.max
 
 public enum class ListType {
@@ -210,8 +203,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
  */
 @Composable public fun <T> RichTextScope.FormattedList(
   listType: ListType,
-  markdownAnimationState: MutableState<MarkdownAnimationState> = mutableStateOf(
-    DefaultMarkdownAnimationState),
+  markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
   items: List<T>,
   drawItem: @Composable RichTextScope.(T) -> Unit
@@ -248,7 +240,8 @@ private val LocalListLevel = compositionLocalOf { 0 }
 
 @Composable private fun rememberAnimation(
   richTextRenderOptions: RichTextRenderOptions,
-  markdownAnimationState: MutableState<MarkdownAnimationState>): State<Float> {
+  markdownAnimationState: MarkdownAnimationState,
+): State<Float> {
   val targetAlpha = remember {
     mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
   }
@@ -259,7 +252,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     targetAlpha.value,
     tween(
       richTextRenderOptions.textFadeInMs,
-      delayMillis = markdownAnimationState.value.toDelayMs(),
+      delayMillis = markdownAnimationState.toDelayMs(),
     )
   )
   return alpha

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -139,7 +139,6 @@ public data class MarkdownAnimationState(
 public val DefaultMarkdownAnimationState: MarkdownAnimationState = MarkdownAnimationState()
 
 @Composable
-@OptIn(FlowPreview::class)
 private fun rememberAnimatedText(
   annotated: AnnotatedString,
   renderOptions: RichTextRenderOptions,
@@ -190,7 +189,7 @@ private fun rememberAnimatedText(
     LaunchedEffect(annotated) {
       // If we detect a new phrase, kick off the animation now.
       val phrases = annotated.segmentIntoPhrases(renderOptions, isComplete = !isLeafText)
-      if (phrases.hasNewPhrasesFrom(readyToAnimateText.value).not()) return@LaunchedEffect
+      if (!phrases.hasNewPhrasesFrom(readyToAnimateText.value)) return@LaunchedEffect
       readyToAnimateText.value = phrases
       animationUpdate()
 

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -263,6 +263,9 @@ private fun AnnotatedString.getConsumableAnnotations(
       ) as? Format.Link
     }
 
+/**
+ * Custom brush allows animating the alpha of this Brush via recompositions only in the draw phase.
+ */
 private data class DynamicSolidColor(private val color: Color, private val alpha: () -> Float) :
   ShaderBrush() {
 

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -232,10 +232,11 @@ private fun AnnotatedString.animateAlphas(
 }
 
 private fun AnnotatedString.changeAlpha(alpha: Float, contentColor: Color): AnnotatedString {
-  val newWordsStyles = spanStyles.map { spanstyle ->
-    spanstyle.copy(item = spanstyle.item.copy(color = spanstyle.item.color.copy(alpha = alpha)))
-  } + listOf(AnnotatedString.Range(SpanStyle(contentColor.copy(alpha = alpha)), 0, length))
-  return AnnotatedString(text, newWordsStyles)
+  val subStyles = spanStyles.map {
+    it.copy(item = it.item.copy(color = it.item.color.copy(alpha = alpha)))
+  }
+  val fullStyle = AnnotatedString.Range(SpanStyle(contentColor.copy(alpha = alpha)), 0, length)
+  return AnnotatedString(text, subStyles + fullStyle)
 }
 
 private fun AnnotatedString.getConsumableAnnotations(

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -181,9 +181,14 @@ private fun rememberAnimatedText(
               renderOptions.onTextAnimate()
             }
           }
-          animations.remove(phraseIndex)
         }
       }
+    // Since animations are already being updated, remove any animations that have finished.
+    animations.forEach { (key, animation) ->
+      if (animation.alpha() == 1f) {
+        animations.remove(key)
+      }
+    }
     if (phrases.isComplete) {
       textToRender.value = phrases.annotatedString
     }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -16,7 +16,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Offset.Companion
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.LinearGradientShader
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
@@ -233,9 +240,19 @@ private fun AnnotatedString.animateAlphas(
 
 private fun AnnotatedString.changeAlpha(alpha: Float, contentColor: Color): AnnotatedString {
   val subStyles = spanStyles.map {
-    it.copy(item = it.item.copy(color = it.item.color.copy(alpha = alpha)))
+    it.copy(
+      item = it.item.copy(
+        brush = DynamicSolidColor { it.item.color.copy(alpha = alpha) },
+      ),
+    )
   }
-  val fullStyle = AnnotatedString.Range(SpanStyle(contentColor.copy(alpha = alpha)), 0, length)
+  val fullStyle = AnnotatedString.Range(
+    SpanStyle(
+      brush = DynamicSolidColor { contentColor.copy(alpha = alpha) },
+    ),
+    0,
+    length,
+  )
   return AnnotatedString(text, subStyles + fullStyle)
 }
 
@@ -251,3 +268,11 @@ private fun AnnotatedString.getConsumableAnnotations(
         textFormatObjects
       ) as? Format.Link
     }
+
+private data class DynamicSolidColor(val color: () -> Color) : ShaderBrush() {
+
+  override fun createShader(size: Size): Shader {
+    val color = color()
+    return LinearGradientShader(Offset.Zero, Offset(size.width, size.height), listOf(color, color))
+  }
+}


### PR DESCRIPTION
A bit of a whopper. The PR is broken up into several commits that outline each change.

At a high-level: This PR has fade animations work by only recomposing in the draw phase. Prior to this PR, animations would cause the actual AnnotatedString to be recreated, causing a wider recomposition scope.

I made some other changes along the way that I thought were helpful, while working in this area.

1. TextAnimation now stores a MutableState for the alpha, so it doesn't have to be recreated on animation change.
2. A DynamicSolid color custom brush is used to read the State. Because effectively the only way to create a custom Brush is via ShaderBrush, we use a LinearGradient with equal color stops to replicate a custom SolidColor brush.
3. Simplified updating the text, using `delay` instead of a Flow to handle debouncing.
4. MarkdownAnimationState args with default values weren't remembering the mutableState. Anyways it seems better to make it a stable state holder instead of passing around a mutable state.
5. Updated Compose dependencies -- this was necessary because originally ShaderBrush was cached and could never be recreated. In newer versions of Compose, it's created in a derivedStateOf and will properly get recreated when States it reads have changed.
7. Added an AnimationSample so that I could test the results visually.