### PR TITLE
Subsequent rememberAnimatedText calls with same text will not generate new AnnotatedString

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -222,7 +223,14 @@ private fun rememberAnimatedText(
     }
   }
 
-  return textToRender.value.animateAlphas(animations.values, contentColor)
+  return remember(contentColor) {
+    derivedStateOf {
+      textToRender.value.animateAlphas(
+        animations.values,
+        contentColor
+      )
+    }
+  }.value
 }
 
 private class TextAnimation(val startIndex: Int) {


### PR DESCRIPTION
When looking into InlineContent, I noticed that it would be possible to trigger recomposition of `Text` even if the text itself hadn't changed, becuase the first time `InlineContent` renders, it updates its placeholder size and requires a recomposition to pass it into a new `ClickableText(...)` call.

In this case, `rememberAnimatedText` would still get called again, which creates a new AnnotatedString inserting the animated spans into `textToRender.value`.

This does seem kind of wasteful. Ideally, `textToRender` would just include the animated spans in the first place. However, we do need to react to potential changes of `contentColor`.

A `remember(contentColor) { derivedStateOf {... } }` does the trick: If contentColor doesn't change, we will continue reusing the previous value of text with its animations, and still read any new values from it. If `contentColor` does change, we create a new state using the new content color nicely.