### PR TITLE
Fix FormattedList for alphabetical markers with index=0

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -253,6 +253,11 @@ private val sampleMarkdown = """
 <!-- -->
   0. Ordered list starting with `0.`
 <!-- -->
+  1.
+      0. Sub-list starting with 0
+      0. Next item
+      0. Next item
+<!-- -->
   003. Ordered list starting with `003.`
 <!-- -->
   -1. Starting with `-1.` should not be list

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -149,13 +149,17 @@ private val DefaultOrderedMarkers: RichTextScope.() -> OrderedMarkers = {
   textOrderedMarkers(
     { "${it + 1}." },
     {
-      ('a'..'z').drop(it % 26)
-        .first() + "."
+      when (it >= 0) {
+        true -> ('a'..'z').drop(it % 26).first() + "."
+        false -> "0."
+      }
     },
     { "${it + 1})" },
     {
-      ('a'..'z').drop(it % 26)
-        .first() + ")"
+      when (it >= 0) {
+        true -> ('a'..'z').drop(it % 26).first() + ")"
+        false -> "0."
+      }
     }
   )
 }


### PR DESCRIPTION
After upstream merge, this case currently fails:

```
1.
    0. Sub-list starting at 0, with empty list item above.
```

It seems like a reasonable way to solve this is to start the list with "0.", even if it's alphabetical.

To test, I added this snippet to MarkdownSample:

```
  1.
      0. Sub-list starting with 0
      0. Next item
      0. Next item
```

<img width="323" alt="image" src="https://github.com/user-attachments/assets/2f8d59e8-0def-41b6-815f-147d77cf5626" />

and here's how GitHub handles it:

  1.
      0. Sub-list starting with 0
      0. Next item
      0. Next item