### PR TITLE
Remove animation spans more aggressively

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -87,7 +87,7 @@ public fun RichTextScope.Text(
       maxLines = maxLines
     )
   } else {
-  val inlineTextConstraints = remember { mutableStateOf(Constraints()) }
+    val inlineTextConstraints = remember { mutableStateOf(Constraints()) }
     val inlineTextContents = manageInlineTextContents(
       inlineContents = inlineContents,
       textConstraints = inlineTextConstraints,
@@ -183,14 +183,10 @@ private fun rememberAnimatedText(
               renderOptions.onTextAnimate()
             }
           }
+          // Remove animation right away, in case it had split at an inappropriate unicode point.
+          animations.remove(phraseIndex)
         }
       }
-    // Since animations are already being updated, remove any animations that have finished.
-    animations.forEach { (key, animation) ->
-      if (animation.alpha == 1f) {
-        animations.remove(key)
-      }
-    }
   }
   LaunchedEffect(isLeafText, annotated) {
     val isComplete = !isLeafText


### PR DESCRIPTION
Keeping the string split by animation spans at incorrect locations could cause unicode text rendering to be broken. In some cases, animation spans were not removed even if once a string had finished animating.

By aggressively removing animation spans as they complete, we can ensure text will be rendered correctly, sooner.