### PR TITLE
More configurable table styles

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.ui.BlockQuote
 import com.halilibo.richtext.ui.CodeBlock
 import com.halilibo.richtext.ui.ColumnArrangement.Adaptive
+import com.halilibo.richtext.ui.DividerStyle
 import com.halilibo.richtext.ui.FormattedList
 import com.halilibo.richtext.ui.Heading
 import com.halilibo.richtext.ui.HorizontalRule
@@ -131,7 +132,9 @@ import com.halilibo.richtext.ui.material3.RichText
       currentStyle.copy(
         tableStyle = currentStyle.tableStyle!!.copy(
           columnArrangement = Adaptive(200.dp),
-          drawVerticalDividers = false,
+          dividerStyle = DividerStyle.Minimal,
+          headerBorderColor = Color.DarkGray,
+          borderColor = Color.LightGray
         )
       )
     ) {

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -129,7 +129,10 @@ import com.halilibo.richtext.ui.material3.RichText
     val currentStyle = style!!
     WithStyle(
       currentStyle.copy(
-        tableStyle = currentStyle.tableStyle!!.copy(columnArrangement = Adaptive(200.dp))
+        tableStyle = currentStyle.tableStyle!!.copy(
+          columnArrangement = Adaptive(200.dp),
+          drawVerticalDividers = false,
+        )
       )
     ) {
       Heading(0, "Scrollable Table")
@@ -137,7 +140,7 @@ import com.halilibo.richtext.ui.material3.RichText
         modifier = Modifier.fillMaxWidth(),
         headerRow = {
           cell { Text("Column 1") }
-          cell { Text("Column 2") }
+          cell { Text("Column 2 has a pretty long title") }
           cell { Text("Column 3") }
           cell { Text("Column 4") }
         }) {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/Table.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/Table.kt
@@ -39,7 +39,8 @@ public data class TableStyle(
   val cellPadding: TextUnit? = null,
   val columnArrangement: ColumnArrangement? = null,
   val borderColor: Color? = null,
-  val borderStrokeWidth: Float? = null
+  val borderStrokeWidth: Float? = null,
+  val drawVerticalDividers: Boolean = DefaultDrawVerticalDividers,
 ) {
   public companion object {
     public val Default: TableStyle = TableStyle()
@@ -56,13 +57,15 @@ private val DefaultCellPadding = 8.sp
 private val DefaultBorderColor = Color.Unspecified
 private val DefaultColumnArrangement = ColumnArrangement.Uniform
 private const val DefaultBorderStrokeWidth = 1f
+private const val DefaultDrawVerticalDividers = true
 
 internal fun TableStyle.resolveDefaults() = TableStyle(
     headerTextStyle = headerTextStyle ?: DefaultTableHeaderTextStyle,
     cellPadding = cellPadding ?: DefaultCellPadding,
     columnArrangement = columnArrangement ?: DefaultColumnArrangement,
     borderColor = borderColor ?: DefaultBorderColor,
-    borderStrokeWidth = borderStrokeWidth ?: DefaultBorderStrokeWidth
+    borderStrokeWidth = borderStrokeWidth ?: DefaultBorderStrokeWidth,
+    drawVerticalDividers = drawVerticalDividers ?: DefaultDrawVerticalDividers,
 )
 
 public interface RichTextTableRowScope {
@@ -179,6 +182,7 @@ public fun RichTextScope.Table(
   TableLayout(
     columns = columns,
     rows = styledRows,
+    hasHeader = header != null,
     cellSpacing = tableStyle.borderStrokeWidth,
     tableMeasurer = measurer,
     drawDecorations = { layoutResult ->
@@ -186,7 +190,8 @@ public fun RichTextScope.Table(
         rowOffsets = layoutResult.rowOffsets,
         columnOffsets = layoutResult.columnOffsets,
         borderColor = tableStyle.borderColor!!.takeOrElse { contentColor },
-        borderStrokeWidth = tableStyle.borderStrokeWidth
+        borderStrokeWidth = tableStyle.borderStrokeWidth,
+        verticalDividers = tableStyle.drawVerticalDividers,
       )
     },
     modifier = tableModifier
@@ -197,7 +202,8 @@ private fun Modifier.drawTableBorders(
   rowOffsets: List<Float>,
   columnOffsets: List<Float>,
   borderColor: Color,
-  borderStrokeWidth: Float
+  borderStrokeWidth: Float,
+  verticalDividers: Boolean,
 ) = drawBehind {
   // Draw horizontal borders.
   rowOffsets.forEach { position ->
@@ -210,12 +216,14 @@ private fun Modifier.drawTableBorders(
   }
 
   // Draw vertical borders.
-  columnOffsets.forEach { position ->
-    drawLine(
+  if (verticalDividers) {
+    columnOffsets.forEach { position ->
+      drawLine(
         borderColor,
         Offset(position, 0f),
         Offset(position, size.height),
         borderStrokeWidth
-    )
+      )
+    }
   }
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/TableLayout.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/TableLayout.kt
@@ -25,6 +25,7 @@ internal data class TableLayoutResult(
 internal fun TableLayout(
   columns: Int,
   rows: List<List<@Composable () -> Unit>>,
+  hasHeader: Boolean,
   drawDecorations: (TableLayoutResult) -> Modifier,
   cellSpacing: Float,
   tableMeasurer: TableMeasurer,
@@ -61,7 +62,14 @@ internal fun TableLayout(
           if (rowIndex == 0) {
             columnOffsets.add(x - cellSpacing / 2f)
           }
-          cell.place(x.roundToInt(), y.roundToInt())
+
+          val cellY = if (hasHeader && rowIndex == 0) {
+            // Header is bottom-aligned
+            y + (measurements.rowHeights[0] - cell.height)
+          } else {
+            y
+          }
+          cell.place(x.roundToInt(), cellY.roundToInt())
           x += measurements.columnWidths[columnIndex] + cellSpacing
         }
 


### PR DESCRIPTION
Addressing some designer requests,
- Table header text should align to the bottom of their cells, when we have variable content heights
- Remove vertical dividers, now configurable via TableStyle
- Lighten table dividers, already configurable
- Darker header divider, now configurable via TableStyle

<img width="350" src="https://github.com/user-attachments/assets/e66440b7-e86e-4219-931b-25a32b157fc2" />
