### PR TITLE
Configurable style for HorizontalRules

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/HorizontalRule.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/HorizontalRule.kt
@@ -6,17 +6,33 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+
+@Immutable
+public data class HorizontalRuleStyle(
+  val color: Color? = null,
+) {
+  public companion object {
+    public val Default: HorizontalRuleStyle = HorizontalRuleStyle()
+  }
+}
+
+internal fun HorizontalRuleStyle.resolveDefaults() = HorizontalRuleStyle(
+  color = color
+)
 
 /**
  * A simple horizontal line drawn with the current content color.
  */
 @Composable public fun RichTextScope.HorizontalRule() {
-  val color = currentContentColor.copy(alpha = .2f)
+  val resolvedStyle = currentRichTextStyle.resolveDefaults()
+  val color = resolvedStyle.horizontalRuleStyle?.color ?: currentContentColor.copy(alpha = .2f)
   val spacing = with(LocalDensity.current) {
-    currentRichTextStyle.resolveDefaults().paragraphSpacing!!.toDp()
+    resolvedStyle.paragraphSpacing!!.toDp()
   }
   Box(
     Modifier

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextStyle.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextStyle.kt
@@ -31,8 +31,9 @@ public data class RichTextStyle(
   val blockQuoteGutter: BlockQuoteGutter? = null,
   val codeBlockStyle: CodeBlockStyle? = null,
   val tableStyle: TableStyle? = null,
+  val horizontalRuleStyle: HorizontalRuleStyle? = null,
   val infoPanelStyle: InfoPanelStyle? = null,
-  val stringStyle: RichTextStringStyle? = null
+  val stringStyle: RichTextStringStyle? = null,
 ) {
   public companion object {
     public val Default: RichTextStyle = RichTextStyle()
@@ -46,8 +47,9 @@ public fun RichTextStyle.merge(otherStyle: RichTextStyle?): RichTextStyle = Rich
   blockQuoteGutter = otherStyle?.blockQuoteGutter ?: blockQuoteGutter,
   codeBlockStyle = otherStyle?.codeBlockStyle ?: codeBlockStyle,
   tableStyle = otherStyle?.tableStyle ?: tableStyle,
+  horizontalRuleStyle = otherStyle?.horizontalRuleStyle ?: horizontalRuleStyle,
   infoPanelStyle = otherStyle?.infoPanelStyle ?: infoPanelStyle,
-  stringStyle = stringStyle?.merge(otherStyle?.stringStyle) ?: otherStyle?.stringStyle
+  stringStyle = stringStyle?.merge(otherStyle?.stringStyle) ?: otherStyle?.stringStyle,
 )
 
 public fun RichTextStyle.resolveDefaults(): RichTextStyle = RichTextStyle(
@@ -57,6 +59,7 @@ public fun RichTextStyle.resolveDefaults(): RichTextStyle = RichTextStyle(
   blockQuoteGutter = blockQuoteGutter ?: DefaultBlockQuoteGutter,
   codeBlockStyle = (codeBlockStyle ?: CodeBlockStyle.Default).resolveDefaults(),
   tableStyle = (tableStyle ?: TableStyle.Default).resolveDefaults(),
+  horizontalRuleStyle = (horizontalRuleStyle ?: HorizontalRuleStyle.Default).resolveDefaults(),
   infoPanelStyle = (infoPanelStyle ?: InfoPanelStyle.Default).resolveDefaults(),
   stringStyle = (stringStyle ?: RichTextStringStyle.Default).resolveDefaults()
 )


### PR DESCRIPTION
We'd like our HorizontalRules to use BorderLight coloring, currently they are not configurable and use the content color with additional alpha. Adding a dedicated style with only color supported for now.