### PR TITLE
Markdown animates in sync

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/AnimationSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/AnimationSample.kt
@@ -327,6 +327,15 @@ private const val SampleText = """
 * Formatted list 1
 * Formatted list 2
   * Sub bullet point
+* Formatted list 3
+* Formatted list 4 but with some very long text
+* **This is a title** And then a lot more text and maybe a story and a much longer block of text and hello there this is a test
+* 7
+* 8
+* 9
+* 10
+
+
 
 # Header 1
 2-The quick brown fox jumps over the lazy dog.

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -230,7 +230,10 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
     when (val astNodeType = astNode.type) {
       is AstDocument -> visitChildren(astNode)
       is AstBlockQuote -> {
-        BlockQuote {
+        BlockQuote(
+          markdownAnimationState = markdownAnimationState,
+          richTextRenderOptions = richTextRenderOptions,
+        ) {
           visitChildren(astNode)
         }
       }
@@ -238,6 +241,8 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       is AstUnorderedList -> {
         FormattedList(
           listType = Unordered,
+          markdownAnimationState = markdownAnimationState,
+          richTextRenderOptions = richTextRenderOptions,
           items = astNode.filterChildrenType<AstListItem>().toList()
         ) { astListItem ->
           // if this list item has no child, it should at least emit a single pixel layout.
@@ -252,6 +257,8 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       is AstOrderedList -> {
         FormattedList(
           listType = Ordered,
+          markdownAnimationState = markdownAnimationState,
+          richTextRenderOptions = richTextRenderOptions,
           items = astNode.childrenSequence().toList(),
           startIndex = astNodeType.startNumber - 1,
         ) { astListItem ->
@@ -265,7 +272,10 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       }
 
       is AstThematicBreak -> {
-        HorizontalRule()
+        HorizontalRule(
+          markdownAnimationState = markdownAnimationState,
+          richTextRenderOptions = richTextRenderOptions,
+        )
       }
 
       is AstHeading -> {
@@ -281,11 +291,19 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       }
 
       is AstIndentedCodeBlock -> {
-        CodeBlock(text = astNodeType.literal.trim())
+        CodeBlock(
+          text = astNodeType.literal.trim(),
+          markdownAnimationState = markdownAnimationState,
+          richTextRenderOptions = richTextRenderOptions,
+        )
       }
 
       is AstFencedCodeBlock -> {
-        CodeBlock(text = astNodeType.literal.trim())
+        CodeBlock(
+          text = astNodeType.literal.trim(),
+          markdownAnimationState = markdownAnimationState,
+          richTextRenderOptions = richTextRenderOptions,
+        )
       }
 
       is AstHtmlBlock -> {

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -20,6 +20,8 @@ internal fun RichTextScope.RenderTable(
   markdownAnimationState: MarkdownAnimationState,
 ) {
   Table(
+    markdownAnimationState = markdownAnimationState,
+    richTextRenderOptions = richtextRenderOptions,
     headerRow = {
       node.filterChildrenType<AstTableHeader>()
         .firstOrNull()

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -20,6 +21,8 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.offset
 import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.BlockQuoteGutter.BarGutter
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
 internal val DefaultBlockQuoteGutter = BarGutter()
 
@@ -67,13 +70,18 @@ public interface BlockQuoteGutter {
 /**
  * Draws a block quote, with a [BlockQuoteGutter] drawn beside the children on the start side.
  */
-@Composable public fun RichTextScope.BlockQuote(children: @Composable RichTextScope.() -> Unit) {
+@Composable public fun RichTextScope.BlockQuote(
+  markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
+  richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+  children: @Composable RichTextScope.() -> Unit
+) {
   val gutter = currentRichTextStyle.resolveDefaults().blockQuoteGutter!!
   val spacing = gutter.verticalContentPadding ?: with(LocalDensity.current) {
     currentRichTextStyle.resolveDefaults().paragraphSpacing!!.toDp() / 2
   }
 
-  Layout(content = {
+  val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
+  Layout(modifier = Modifier.alpha(alpha.value), content = {
     with(gutter) { drawGutter() }
     BasicRichText(
       modifier = Modifier.padding(top = spacing, bottom = spacing),

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -81,7 +82,7 @@ public interface BlockQuoteGutter {
   }
 
   val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
-  Layout(modifier = Modifier.alpha(alpha.value), content = {
+  Layout(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }, content = {
     with(gutter) { drawGutter() }
     BasicRichText(
       modifier = Modifier.padding(top = spacing, bottom = spacing),

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
@@ -5,13 +5,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
 /**
  * Defines how [CodeBlock]s are rendered.
@@ -57,9 +61,15 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
  */
 @Composable public fun RichTextScope.CodeBlock(
   text: String,
+  markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
+  richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
   wordWrap: Boolean? = null
 ) {
-  CodeBlock(wordWrap = wordWrap) {
+  CodeBlock(
+    wordWrap = wordWrap,
+    markdownAnimationState = markdownAnimationState,
+    richTextRenderOptions = richTextRenderOptions,
+  ) {
     Text(text)
   }
 }
@@ -72,6 +82,8 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
  */
 @Composable public fun RichTextScope.CodeBlock(
   wordWrap: Boolean? = null,
+  markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
+  richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
   children: @Composable RichTextScope.() -> Unit
 ) {
   val codeBlockStyle = currentRichTextStyle.resolveDefaults().codeBlockStyle!!
@@ -81,12 +93,14 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
     codeBlockStyle.padding!!.toDp()
   }
   val resolvedWordWrap = wordWrap ?: codeBlockStyle.wordWrap!!
+  val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
 
   CodeBlockLayout(
     wordWrap = resolvedWordWrap
   ) { layoutModifier ->
     Box(
       modifier = layoutModifier
+        .alpha(alpha.value)
         .then(modifier)
         .padding(blockPadding)
     ) {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
@@ -100,7 +101,7 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
   ) { layoutModifier ->
     Box(
       modifier = layoutModifier
-        .alpha(alpha.value)
+        .graphicsLayer{ this.alpha = alpha.value }
         .then(modifier)
         .padding(blockPadding)
     ) {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -221,7 +221,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     itemSpacing = itemSpacing,
     prefixPadding = PaddingValues(start = markerIndent, end = contentsIndent),
     prefixForIndex = { index ->
-      val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState, index)
+      val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
       Box(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }) {
         when (listType) {
           Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -2,8 +2,6 @@
 
 package com.halilibo.richtext.ui
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
@@ -11,10 +9,7 @@ import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -225,7 +220,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     itemSpacing = itemSpacing,
     prefixPadding = PaddingValues(start = markerIndent, end = contentsIndent),
     prefixForIndex = { index ->
-      val alpha = rememberAnimation(richTextRenderOptions, markdownAnimationState)
+      val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
       Box(modifier = Modifier.alpha(alpha.value)) {
         when (listType) {
           Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)
@@ -243,26 +238,6 @@ private val LocalListLevel = compositionLocalOf { 0 }
       }
     }
   )
-}
-
-@Composable private fun rememberAnimation(
-  richTextRenderOptions: RichTextRenderOptions,
-  markdownAnimationState: MarkdownAnimationState,
-): State<Float> {
-  val targetAlpha = remember {
-    mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
-  }
-  LaunchedEffect(Unit) {
-    targetAlpha.value = 1f
-  }
-  val alpha = animateFloatAsState(
-    targetAlpha.value,
-    tween(
-      richTextRenderOptions.textFadeInMs,
-      delayMillis = markdownAnimationState.toDelayMs(),
-    )
-  )
-  return alpha
 }
 
 @Composable private fun PrefixListLayout(

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.paint
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
@@ -221,7 +222,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     prefixPadding = PaddingValues(start = markerIndent, end = contentsIndent),
     prefixForIndex = { index ->
       val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
-      Box(modifier = Modifier.alpha(alpha.value)) {
+      Box(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }) {
         when (listType) {
           Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)
           Unordered -> listStyle.unorderedMarkers!!().drawMarker(currentLevel)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -221,7 +221,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     itemSpacing = itemSpacing,
     prefixPadding = PaddingValues(start = markerIndent, end = contentsIndent),
     prefixForIndex = { index ->
-      val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
+      val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState, index)
       Box(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }) {
         when (listType) {
           Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/HorizontalRule.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/HorizontalRule.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
 @Immutable
 public data class HorizontalRuleStyle(
@@ -31,15 +35,20 @@ internal fun HorizontalRuleStyle.resolveDefaults() = HorizontalRuleStyle(
 /**
  * A simple horizontal line drawn with the current content color.
  */
-@Composable public fun RichTextScope.HorizontalRule() {
+@Composable public fun RichTextScope.HorizontalRule(
+  markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
+  richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+) {
   val resolvedStyle = currentRichTextStyle.resolveDefaults()
   val horizontalRuleStyle = resolvedStyle.horizontalRuleStyle
   val color = horizontalRuleStyle?.color ?: currentContentColor.copy(alpha = .2f)
   val spacing = horizontalRuleStyle?.spacing ?: with(LocalDensity.current) {
     resolvedStyle.paragraphSpacing!!.toDp()
   }
+  val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
   Box(
     Modifier
+      .alpha(alpha.value)
       .padding(top = spacing, bottom = spacing)
       .fillMaxWidth()
       .height(1.dp)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/HorizontalRule.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/HorizontalRule.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -48,7 +49,7 @@ internal fun HorizontalRuleStyle.resolveDefaults() = HorizontalRuleStyle(
   val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
   Box(
     Modifier
-      .alpha(alpha.value)
+      .graphicsLayer{ this.alpha = alpha.value }
       .padding(top = spacing, bottom = spacing)
       .fillMaxWidth()
       .height(1.dp)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
@@ -1,0 +1,35 @@
+package com.halilibo.richtext.ui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
+
+@Composable
+internal fun rememberMarkdownFade(
+  richTextRenderOptions: RichTextRenderOptions,
+  markdownAnimationState: MarkdownAnimationState,
+): State<Float> {
+  val targetAlpha = remember {
+    mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
+  }
+  LaunchedEffect(Unit) {
+    targetAlpha.value = 1f
+  }
+  val alpha = animateFloatAsState(
+    targetAlpha.value,
+    tween(
+      durationMillis = richTextRenderOptions.textFadeInMs,
+      delayMillis = markdownAnimationState.toDelayMs(),
+    )
+  )
+  LaunchedEffect(Unit) {
+    markdownAnimationState.addAnimation(richTextRenderOptions)
+  }
+  return alpha
+}

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
@@ -19,7 +19,6 @@ import kotlin.time.Duration.Companion.milliseconds
 internal fun rememberMarkdownFade(
   richTextRenderOptions: RichTextRenderOptions,
   markdownAnimationState: MarkdownAnimationState,
-  childIndex: Int = 0,
 ): State<Float> {
   val coroutineScope = rememberCoroutineScope()
   val targetAlpha = remember {
@@ -28,7 +27,8 @@ internal fun rememberMarkdownFade(
   LaunchedEffect(Unit) {
     if (richTextRenderOptions.animate) {
       coroutineScope.launch {
-        delay(markdownAnimationState.predictDelayForOffset(childIndex, richTextRenderOptions).milliseconds)
+        markdownAnimationState.addAnimation(richTextRenderOptions)
+        delay(markdownAnimationState.toDelayMs().milliseconds)
         targetAlpha.animateTo(
           1f,
           tween(

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
@@ -1,5 +1,6 @@
 package com.halilibo.richtext.ui
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
@@ -18,25 +19,24 @@ import kotlin.time.Duration.Companion.milliseconds
 internal fun rememberMarkdownFade(
   richTextRenderOptions: RichTextRenderOptions,
   markdownAnimationState: MarkdownAnimationState,
+  childIndex: Int = 0,
 ): State<Float> {
   val coroutineScope = rememberCoroutineScope()
   val targetAlpha = remember {
-    mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
+    Animatable(if (richTextRenderOptions.animate) 0f else 1f)
   }
   LaunchedEffect(Unit) {
     if (richTextRenderOptions.animate) {
       coroutineScope.launch {
-        markdownAnimationState.addAnimation(richTextRenderOptions)
-        delay(markdownAnimationState.toDelayMs().milliseconds)
-        targetAlpha.floatValue = 1f
+        delay(markdownAnimationState.predictDelayForOffset(childIndex, richTextRenderOptions).milliseconds)
+        targetAlpha.animateTo(
+          1f,
+          tween(
+            durationMillis = richTextRenderOptions.textFadeInMs,
+          )
+        )
       }
     }
   }
-  val alpha = animateFloatAsState(
-    targetAlpha.floatValue,
-    tween(
-      durationMillis = richTextRenderOptions.textFadeInMs,
-    )
-  )
-  return alpha
+  return targetAlpha.asState()
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
@@ -1,46 +1,42 @@
 package com.halilibo.richtext.ui
 
-import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 internal fun rememberMarkdownFade(
   richTextRenderOptions: RichTextRenderOptions,
   markdownAnimationState: MarkdownAnimationState,
-  enqueue: Boolean = true,
 ): State<Float> {
   val coroutineScope = rememberCoroutineScope()
-  val alpha = remember { mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f) }
+  val targetAlpha = remember {
+    mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
+  }
   LaunchedEffect(Unit) {
-    if (enqueue) {
+    if (richTextRenderOptions.animate) {
       coroutineScope.launch {
         markdownAnimationState.addAnimation(richTextRenderOptions)
-        animate(
-          initialValue = 0f,
-          targetValue = 1f,
-          animationSpec = tween(
-            durationMillis = richTextRenderOptions.textFadeInMs,
-            delayMillis = markdownAnimationState.toDelayMs(),
-          )
-        ) { value, _ ->
-          alpha.floatValue = value
-        }
+        delay(markdownAnimationState.toDelayMs().milliseconds)
+        targetAlpha.floatValue = 1f
       }
-    } else {
-      alpha.floatValue = 1f
     }
   }
+  val alpha = animateFloatAsState(
+    targetAlpha.floatValue,
+    tween(
+      durationMillis = richTextRenderOptions.textFadeInMs,
+    )
+  )
   return alpha
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
@@ -14,12 +14,10 @@ import com.halilibo.richtext.ui.string.RichTextRenderOptions
 internal fun rememberMarkdownFade(
   richTextRenderOptions: RichTextRenderOptions,
   markdownAnimationState: MarkdownAnimationState,
+  enqueue: Boolean = false,
 ): State<Float> {
   val targetAlpha = remember {
     mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
-  }
-  LaunchedEffect(Unit) {
-    targetAlpha.value = 1f
   }
   val alpha = animateFloatAsState(
     targetAlpha.value,
@@ -29,7 +27,10 @@ internal fun rememberMarkdownFade(
     )
   )
   LaunchedEffect(Unit) {
-    markdownAnimationState.addAnimation(richTextRenderOptions)
+    if (enqueue) {
+      markdownAnimationState.addAnimation(richTextRenderOptions)
+    }
+    targetAlpha.value = 1f
   }
   return alpha
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MarkdownAnimation.kt
@@ -1,36 +1,46 @@
 package com.halilibo.richtext.ui
 
+import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun rememberMarkdownFade(
   richTextRenderOptions: RichTextRenderOptions,
   markdownAnimationState: MarkdownAnimationState,
-  enqueue: Boolean = false,
+  enqueue: Boolean = true,
 ): State<Float> {
-  val targetAlpha = remember {
-    mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f)
-  }
-  val alpha = animateFloatAsState(
-    targetAlpha.value,
-    tween(
-      durationMillis = richTextRenderOptions.textFadeInMs,
-      delayMillis = markdownAnimationState.toDelayMs(),
-    )
-  )
+  val coroutineScope = rememberCoroutineScope()
+  val alpha = remember { mutableFloatStateOf(if (richTextRenderOptions.animate) 0f else 1f) }
   LaunchedEffect(Unit) {
     if (enqueue) {
-      markdownAnimationState.addAnimation(richTextRenderOptions)
+      coroutineScope.launch {
+        markdownAnimationState.addAnimation(richTextRenderOptions)
+        animate(
+          initialValue = 0f,
+          targetValue = 1f,
+          animationSpec = tween(
+            durationMillis = richTextRenderOptions.textFadeInMs,
+            delayMillis = markdownAnimationState.toDelayMs(),
+          )
+        ) { value, _ ->
+          alpha.floatValue = value
+        }
+      }
+    } else {
+      alpha.floatValue = 1f
     }
-    targetAlpha.value = 1f
   }
   return alpha
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/Table.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/Table.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
@@ -188,7 +189,7 @@ public fun RichTextScope.Table(
     }
   }
 
-  val baseModifier = modifier.alpha(alpha.value)
+  val baseModifier = modifier.graphicsLayer { this.alpha = alpha.value }
   val tableModifier = if (columnArrangement is Adaptive) {
     baseModifier.horizontalScroll(rememberScrollState())
   } else {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/Table.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/Table.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
@@ -22,6 +23,8 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.ColumnArrangement.Adaptive
 import com.halilibo.richtext.ui.ColumnArrangement.Uniform
+import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -112,10 +115,13 @@ private class RowBuilder : RichTextTableCellScope {
 @Composable
 public fun RichTextScope.Table(
   modifier: Modifier = Modifier,
+  markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
+  richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
   headerRow: (RichTextTableCellScope.() -> Unit)? = null,
   bodyRows: RichTextTableRowScope.() -> Unit
 ) {
   val tableStyle = currentRichTextStyle.resolveDefaults().tableStyle!!
+  val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
   val contentColor = currentContentColor
   val header = remember(headerRow) {
     headerRow?.let { RowBuilder().apply(headerRow).row }
@@ -182,10 +188,11 @@ public fun RichTextScope.Table(
     }
   }
 
+  val baseModifier = modifier.alpha(alpha.value)
   val tableModifier = if (columnArrangement is Adaptive) {
-    modifier.horizontalScroll(rememberScrollState())
+    baseModifier.horizontalScroll(rememberScrollState())
   } else {
-    modifier
+    baseModifier
   }
 
   val borderColor = tableStyle.borderColor!!.takeOrElse { contentColor }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -132,8 +132,6 @@ public class MarkdownAnimationState {
       else -> diffMs + (renderOptions.delayMs * (renderOptions.delayMs / diffMs.toDouble()).pow(
         renderOptions.delayExponent
       )).toLong()
-    }.also {
-      println("Calculated delay: $it now: $now last: $lastAnimationStartMs diff: $diffMs")
     }
   }
 

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -118,10 +118,10 @@ public class MarkdownAnimationState {
   private var lastAnimationStartMs by mutableLongStateOf(0L)
 
   public fun addAnimation(renderOptions: RichTextRenderOptions) {
-    lastAnimationStartMs = calculatedDelay(lastAnimationStartMs, renderOptions) + System.currentTimeMillis()
+    lastAnimationStartMs = calculatedDelay(renderOptions) + System.currentTimeMillis()
   }
 
-  private fun calculatedDelay(lastAnimationStartMs: Long, renderOptions: RichTextRenderOptions): Long {
+  private fun calculatedDelay(renderOptions: RichTextRenderOptions): Long {
     val now = System.currentTimeMillis()
     val diffMs = lastAnimationStartMs - now
 
@@ -133,14 +133,6 @@ public class MarkdownAnimationState {
         renderOptions.delayExponent
       )).toLong()
     }
-  }
-
-  public fun predictDelayForOffset(offset: Int, renderOptions: RichTextRenderOptions): Int {
-    var calculatedStartMs = lastAnimationStartMs
-    for (i in 0 until offset * 3) {
-      calculatedStartMs = calculatedDelay(calculatedStartMs, renderOptions) + System.currentTimeMillis()
-    }
-    return (calculatedStartMs - System.currentTimeMillis()).coerceAtLeast(0).toInt()
   }
 
   public fun toDelayMs(): Int =

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -118,10 +118,10 @@ public class MarkdownAnimationState {
   private var lastAnimationStartMs by mutableLongStateOf(0L)
 
   public fun addAnimation(renderOptions: RichTextRenderOptions) {
-    lastAnimationStartMs = calculatedDelay(renderOptions) + System.currentTimeMillis()
+    lastAnimationStartMs = calculatedDelay(lastAnimationStartMs, renderOptions) + System.currentTimeMillis()
   }
 
-  private fun calculatedDelay(renderOptions: RichTextRenderOptions): Long {
+  private fun calculatedDelay(lastAnimationStartMs: Long, renderOptions: RichTextRenderOptions): Long {
     val now = System.currentTimeMillis()
     val diffMs = lastAnimationStartMs - now
 
@@ -133,6 +133,14 @@ public class MarkdownAnimationState {
         renderOptions.delayExponent
       )).toLong()
     }
+  }
+
+  public fun predictDelayForOffset(offset: Int, renderOptions: RichTextRenderOptions): Int {
+    var calculatedStartMs = lastAnimationStartMs
+    for (i in 0 until offset * 3) {
+      calculatedStartMs = calculatedDelay(calculatedStartMs, renderOptions) + System.currentTimeMillis()
+    }
+    return (calculatedStartMs - System.currentTimeMillis()).coerceAtLeast(0).toInt()
   }
 
   public fun toDelayMs(): Int =


### PR DESCRIPTION
A redo of https://github.com/openai/compose-richtext/pull/42 separating out some of the phrase changes I made. The key was to make sure we launch everything in the shared coroutineScope to queue all the elements properly

<img width="1455" height="989" alt="image" src="https://github.com/user-attachments/assets/b02de76b-3278-4e2d-b8a8-8f0328dd032f" />


[Screen_recording_20250822_132709.webm](https://github.com/user-attachments/assets/908aee12-c5ea-4efa-95f0-08791a19a8cc)
