### PR TITLE
Dotted and dashed underline support for annotated links

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -74,7 +74,7 @@ import com.halilibo.richtext.ui.string.withFormat
     val dottedLinkDecorations = RichTextDecorations(
       linkDecorations = listOf(
         LinkDecoration(
-          matcher = { destination -> destination.contains("dotted") },
+          matcher = { destination, _ -> destination.contains("dotted") },
           underlineStyle = UnderlineStyle.Dotted(),
           linkStyleOverride = { base ->
             TextLinkStyles(

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -32,6 +32,13 @@ import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.Table
 import com.halilibo.richtext.ui.WithStyle
 import com.halilibo.richtext.ui.material3.RichText
+import com.halilibo.richtext.ui.string.LinkDecoration
+import com.halilibo.richtext.ui.string.RichTextDecorations
+import com.halilibo.richtext.ui.string.RichTextString
+import com.halilibo.richtext.ui.string.Text as RichTextText
+import com.halilibo.richtext.ui.string.UnderlineStyle
+import com.halilibo.richtext.ui.string.richTextString
+import com.halilibo.richtext.ui.string.withFormat
 
 @Preview(widthDp = 300, heightDp = 1000)
 @Composable fun RichTextDemoOnWhite() {
@@ -61,6 +68,27 @@ import com.halilibo.richtext.ui.material3.RichText
     Text("Simple paragraph.")
     Text("Paragraph with\nmultiple lines.")
     Text("Paragraph with really long line that should be getting wrapped.")
+    val dottedLinkDecorations = RichTextDecorations(
+      linkDecorations = listOf(
+        LinkDecoration(
+          matcher = { destination -> destination.contains("dotted") },
+          underlineStyle = UnderlineStyle.Dotted(),
+        ),
+      ),
+    )
+    val dottedUnderlineText = richTextString {
+      append("Dotted underline with wrapping: ")
+      withFormat(RichTextString.Format.Link("https://example.com/dotted")) {
+        append(
+          "This is a long link that should wrap across multiple lines to show the " +
+              "dotted underline.",
+        )
+      }
+    }
+    RichTextText(
+      text = dottedUnderlineText,
+      decorations = dottedLinkDecorations,
+    )
     TextPreview()
 
     Heading(0, "Lists")

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.ui.BlockQuote
@@ -68,11 +70,20 @@ import com.halilibo.richtext.ui.string.withFormat
     Text("Simple paragraph.")
     Text("Paragraph with\nmultiple lines.")
     Text("Paragraph with really long line that should be getting wrapped.")
+    val bodyTextColor = LocalContentColor.current
     val dottedLinkDecorations = RichTextDecorations(
       linkDecorations = listOf(
         LinkDecoration(
           matcher = { destination -> destination.contains("dotted") },
           underlineStyle = UnderlineStyle.Dotted(),
+          linkStyleOverride = { base ->
+            TextLinkStyles(
+              style = (base?.style ?: SpanStyle()).copy(color = bodyTextColor),
+              focusedStyle = base?.focusedStyle?.copy(color = bodyTextColor),
+              hoveredStyle = base?.hoveredStyle?.copy(color = bodyTextColor),
+              pressedStyle = base?.pressedStyle?.copy(color = bodyTextColor),
+            )
+          },
         ),
       ),
     )

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -132,11 +132,11 @@ import com.halilibo.richtext.ui.string.UnderlineStyle
             RichTextDecorations(
               linkDecorations = listOf(
                 LinkDecoration(
-                  matcher = { destination -> destination.contains("dotted") },
+                  matcher = { destination, _ -> destination.contains("dotted") },
                   underlineStyle = UnderlineStyle.Dotted(),
                 ),
                 LinkDecoration(
-                  matcher = { destination -> destination.contains("dashed") },
+                  matcher = { destination, _ -> destination.contains("dashed") },
                   underlineStyle = UnderlineStyle.Dashed(),
                 ),
               ),

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -48,7 +48,10 @@ import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.LinkDecoration
+import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
+import com.halilibo.richtext.ui.string.UnderlineStyle
 
 @Preview
 @Composable private fun MarkdownSamplePreview() {
@@ -125,13 +128,31 @@ import com.halilibo.richtext.ui.string.RichTextRenderOptions
           val astNode = remember(parser) {
             parser.parse(sampleMarkdown)
           }
+          val richTextDecorations = remember {
+            RichTextDecorations(
+              linkDecorations = listOf(
+                LinkDecoration(
+                  matcher = { destination -> destination.contains("dotted") },
+                  underlineStyle = UnderlineStyle.Dotted(),
+                ),
+                LinkDecoration(
+                  matcher = { destination -> destination.contains("dashed") },
+                  underlineStyle = UnderlineStyle.Dashed(),
+                ),
+              ),
+            )
+          }
 
           ProvideToastUriHandler(context) {
             RichText(
               style = richTextStyle,
               modifier = Modifier.padding(8.dp),
             ) {
-              BasicMarkdown(astNode, astBlockNodeComposer = HeadingAstBlockNodeComposer)
+              BasicMarkdown(
+                astNode = astNode,
+                richTextDecorations = richTextDecorations,
+                astBlockNodeComposer = HeadingAstBlockNodeComposer,
+              )
             }
           }
         }
@@ -150,6 +171,7 @@ val HeadingAstBlockNodeComposer = object : AstBlockNodeComposer {
     contentOverride: ContentOverride?,
     inlineContentOverride: InlineContentOverride?,
     richTextRenderOptions: RichTextRenderOptions,
+    richTextDecorations: RichTextDecorations,
     markdownAnimationState: MarkdownAnimationState,
     visitChildren: @Composable (AstNode) -> Unit
   ) {
@@ -185,6 +207,11 @@ private fun CheckboxPreference(
 private val sampleMarkdown = """
   # Demo
   Based on [this cheatsheet][cheatsheet]
+
+  ## Link underline styles
+  - [Dotted underline example](https://example.com/dotted)
+  - [Dashed underline example](https://example.com/dashed)
+  - [Default underline example](https://example.com/solid)
 
   ---
 

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/commonmark/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/commonmark/Markdown.kt
@@ -12,7 +12,7 @@ import com.halilibo.richtext.markdown.ContentOverride
 import com.halilibo.richtext.markdown.InlineContentOverride
 import com.halilibo.richtext.markdown.node.AstNode
 import com.halilibo.richtext.ui.RichTextScope
-import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import org.commonmark.node.Node
 
@@ -29,6 +29,7 @@ public fun RichTextScope.Markdown(
   content: String,
   markdownParseOptions: CommonMarkdownParseOptions = CommonMarkdownParseOptions.Default,
   richtextRenderOptions: RichTextRenderOptions = RichTextRenderOptions.Default,
+  richTextDecorations: RichTextDecorations = RichTextDecorations(),
   contentOverride: ContentOverride? = null,
   inlineContentOverride: InlineContentOverride? = null,
   astBlockNodeComposer: AstBlockNodeComposer? = null
@@ -51,6 +52,7 @@ public fun RichTextScope.Markdown(
       contentOverride = contentOverride,
       inlineContentOverride = inlineContentOverride,
       richTextRenderOptions = richtextRenderOptions,
+      richTextDecorations = richTextDecorations,
       astBlockNodeComposer = astBlockNodeComposer,
     )
   }
@@ -66,6 +68,7 @@ public fun RichTextScope.Markdown(
 public fun RichTextScope.Markdown(
   content: Node,
   richtextRenderOptions: RichTextRenderOptions = RichTextRenderOptions.Default,
+  richTextDecorations: RichTextDecorations = RichTextDecorations(),
   contentOverride: ContentOverride? = null,
   inlineContentOverride: InlineContentOverride? = null,
   astBlockNodeComposer: AstBlockNodeComposer? = null
@@ -76,6 +79,7 @@ public fun RichTextScope.Markdown(
     contentOverride,
     inlineContentOverride,
     richtextRenderOptions,
+    richTextDecorations,
     astBlockNodeComposer,
   )
 }

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -37,6 +37,7 @@ import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.string.RichTextRenderOptions.Companion
 import com.halilibo.richtext.ui.string.RichTextString
@@ -80,6 +81,7 @@ public fun RichTextScope.BasicMarkdown(
   contentOverride: ContentOverride? = null,
   inlineContentOverride: InlineContentOverride? = null,
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions.Default,
+  richTextDecorations: RichTextDecorations = RichTextDecorations(),
   astBlockNodeComposer: AstBlockNodeComposer? = null,
 ) {
   RecursiveRenderMarkdownAst(
@@ -87,6 +89,7 @@ public fun RichTextScope.BasicMarkdown(
     contentOverride = contentOverride,
     inlineContentOverride = inlineContentOverride,
     richTextRenderOptions = richTextRenderOptions,
+    richTextDecorations = richTextDecorations,
     markdownAnimationState = remember { MarkdownAnimationState() },
     astNodeComposer = astBlockNodeComposer,
   )
@@ -116,6 +119,7 @@ public interface AstBlockNodeComposer {
     contentOverride: ContentOverride?,
     inlineContentOverride: InlineContentOverride?,
     richTextRenderOptions: RichTextRenderOptions,
+    richTextDecorations: RichTextDecorations,
     markdownAnimationState: MarkdownAnimationState,
     visitChildren: @Composable (AstNode) -> Unit
   )
@@ -152,6 +156,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
   contentOverride: ContentOverride?,
   inlineContentOverride: InlineContentOverride?,
   richTextRenderOptions: RichTextRenderOptions,
+  richTextDecorations: RichTextDecorations,
   markdownAnimationState: MarkdownAnimationState,
   astNodeComposer: AstBlockNodeComposer?
 ) {
@@ -163,6 +168,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
         contentOverride,
         inlineContentOverride,
         richTextRenderOptions,
+        richTextDecorations,
         markdownAnimationState,
         astNodeComposer,
       )
@@ -180,6 +186,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
         contentOverride,
         inlineContentOverride,
         richTextRenderOptions,
+        richTextDecorations,
         markdownAnimationState,
       ) {
         renderChildren(
@@ -187,6 +194,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
           contentOverride,
           inlineContentOverride = inlineContentOverride,
           richTextRenderOptions = richTextRenderOptions,
+          richTextDecorations = richTextDecorations,
           markdownAnimationState = markdownAnimationState,
           astNodeComposer = astNodeComposer
         )
@@ -199,6 +207,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
         contentOverride,
         inlineContentOverride = inlineContentOverride,
         richTextRenderOptions = richTextRenderOptions,
+        richTextDecorations = richTextDecorations,
         markdownAnimationState = markdownAnimationState,
         visitChildren = {
           renderChildren(
@@ -206,6 +215,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(
             contentOverride,
             inlineContentOverride = inlineContentOverride,
             richTextRenderOptions = richTextRenderOptions,
+            richTextDecorations = richTextDecorations,
             markdownAnimationState = markdownAnimationState,
             astNodeComposer = astNodeComposer
           )
@@ -224,6 +234,7 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
     contentOverride: ContentOverride?,
     inlineContentOverride: InlineContentOverride?,
     richTextRenderOptions: RichTextRenderOptions,
+    richTextDecorations: RichTextDecorations,
     markdownAnimationState: MarkdownAnimationState,
     visitChildren: @Composable (AstNode) -> Unit
   ) {
@@ -284,6 +295,7 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
             astNode,
             inlineContentOverride,
             richTextRenderOptions,
+            richTextDecorations,
             markdownAnimationState,
             modifier = Modifier.semantics { heading() },
           )
@@ -324,12 +336,19 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
           astNode,
           inlineContentOverride,
           richTextRenderOptions,
+          richTextDecorations,
           markdownAnimationState,
         )
       }
 
       is AstTableRoot -> {
-        RenderTable(astNode, inlineContentOverride, richTextRenderOptions, markdownAnimationState)
+        RenderTable(
+          astNode,
+          inlineContentOverride,
+          richTextRenderOptions,
+          richTextDecorations,
+          markdownAnimationState,
+        )
       }
       // This should almost never happen. All the possible text
       // nodes must be under either Heading, Paragraph or CustomNode
@@ -371,6 +390,7 @@ internal fun RichTextScope.renderChildren(
   contentOverride: ContentOverride?,
   inlineContentOverride: InlineContentOverride?,
   richTextRenderOptions: RichTextRenderOptions,
+  richTextDecorations: RichTextDecorations,
   markdownAnimationState: MarkdownAnimationState,
   astNodeComposer: AstBlockNodeComposer?
 ) {
@@ -380,6 +400,7 @@ internal fun RichTextScope.renderChildren(
       contentOverride = contentOverride,
       inlineContentOverride = inlineContentOverride,
       richTextRenderOptions = richTextRenderOptions,
+      richTextDecorations = richTextDecorations,
       markdownAnimationState = markdownAnimationState,
       astNodeComposer = astNodeComposer,
     )

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -30,6 +30,7 @@ import com.halilibo.richtext.ui.FormattedList
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.string.RichTextString
 import com.halilibo.richtext.ui.string.Text
@@ -63,6 +64,7 @@ internal fun RichTextScope.MarkdownRichText(
   astNode: AstNode,
   inlineContentOverride: InlineContentOverride?,
   richTextRenderOptions: RichTextRenderOptions,
+  richTextDecorations: RichTextDecorations,
   markdownAnimationState: MarkdownAnimationState,
   modifier: Modifier = Modifier,
 ) {
@@ -77,6 +79,7 @@ internal fun RichTextScope.MarkdownRichText(
     isLeafText = astNode.isLastInTree(),
     renderOptions = richTextRenderOptions,
     sharedAnimationState = markdownAnimationState,
+    decorations = richTextDecorations,
   )
 }
 

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -1,7 +1,6 @@
 package com.halilibo.richtext.markdown
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import com.halilibo.richtext.markdown.node.AstNode
 import com.halilibo.richtext.markdown.node.AstTableBody
 import com.halilibo.richtext.markdown.node.AstTableCell
@@ -10,6 +9,7 @@ import com.halilibo.richtext.markdown.node.AstTableRow
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.Table
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
+import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
 @Composable
@@ -17,6 +17,7 @@ internal fun RichTextScope.RenderTable(
   node: AstNode,
   inlineContentOverride: InlineContentOverride?,
   richtextRenderOptions: RichTextRenderOptions,
+  richTextDecorations: RichTextDecorations,
   markdownAnimationState: MarkdownAnimationState,
 ) {
   Table(
@@ -34,6 +35,7 @@ internal fun RichTextScope.RenderTable(
               tableCell,
               inlineContentOverride,
               richtextRenderOptions,
+              richTextDecorations,
               markdownAnimationState,
             )
           }
@@ -52,11 +54,12 @@ internal fun RichTextScope.RenderTable(
                   tableCell,
                   inlineContentOverride,
                   richtextRenderOptions,
+                  richTextDecorations,
                   markdownAnimationState,
                 )
               }
             }
         }
-      }
+    }
   }
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
@@ -1,0 +1,41 @@
+package com.halilibo.richtext.ui.string
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.TextLinkStyles
+
+/**
+ * Defines how specific links should be decorated based on their destination.
+ */
+public data class LinkDecoration(
+  val matcher: (String) -> Boolean,
+  val underlineStyle: UnderlineStyle = UnderlineStyle.Solid,
+  val linkStyleOverride: ((TextLinkStyles?) -> TextLinkStyles)? = null,
+)
+
+/**
+ * Collection of decorations to apply when rendering a [RichTextString].
+ */
+public data class RichTextDecorations(
+  val linkDecorations: List<LinkDecoration> = emptyList(),
+)
+
+/**
+ * The underline style to use for a matched link.
+ */
+public sealed class UnderlineStyle {
+  public object Solid : UnderlineStyle()
+
+  public data class Dotted(
+    val strokeWidth: Dp = 1.dp,
+    val gap: Dp = 2.dp,
+    val offset: Dp = 0.dp,
+  ) : UnderlineStyle()
+
+  public data class Dashed(
+    val dash: Dp = 6.dp,
+    val gap: Dp = 4.dp,
+    val strokeWidth: Dp = 1.dp,
+    val offset: Dp = 1.dp,
+  ) : UnderlineStyle()
+}

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.TextLinkStyles
  * Defines how specific links should be decorated based on their destination.
  */
 public data class LinkDecoration(
-  val matcher: (String) -> Boolean,
+  val matcher: (destination: String, text: String) -> Boolean,
   val underlineStyle: UnderlineStyle = UnderlineStyle.Solid,
   val linkStyleOverride: ((TextLinkStyles?) -> TextLinkStyles)? = null,
 )


### PR DESCRIPTION
  ## Summary
  Adds first-class link decoration support to compose-richtext so consumers can render dotted/dashed underlines that respect line wrapping, and wires the API through Markdown rendering.
  Updates the demo to showcase the new styles and line wrapping.

  ## Changes
  - New API: `RichTextDecorations`, `LinkDecoration`, and `UnderlineStyle` to customize link underline styles.
  - Link rendering now suppresses default underline when a custom underline is applied.
  - Underline rendering uses `TextLayoutResult` to draw line-aware dotted/dashed underlines.
  - Markdown entrypoints and renderers pass `richTextDecorations` through.
  - Demo updated with dotted/dashed link examples and a long, wrapping dotted link.
  - `AstBlockNodeComposer.Compose` signature updated to include `richTextDecorations`.

  ## Behavior
  - Links matched by `LinkDecoration.matcher` can render dotted/dashed underlines while preserving default behavior for other links.
  - Underlines follow line wraps and align visually with text layout.

  ## Testing

<img width="350" alt="Screenshot_20260120_222718" src="https://github.com/user-attachments/assets/fd3cd939-0ab7-486d-bd6d-9c5b69fc43c7" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/d8310ddc-58ae-47bf-823e-059b90445df4" />

  ## Notes / Compatibility
  - Any custom `AstBlockNodeComposer` implementations must add the new `richTextDecorations` parameter.

  ## Follow-ups
  - Add inline image override API to compose-richtext for parity with app-side reflection logic.
  - Consider consolidating underline styles into a `CustomDash` if we want a single style type.

  ## Codex
  Prompt/context: “Add reusable dotted/dashed underline support for links in compose-richtext; draw underlines using `TextLayoutResult` so they respect wrapping. Wire through Markdown and update the demo to show long wrapped dotted underline examples.”