### PR TITLE
Add leading and trailing icon link decorations

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -14,10 +14,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +36,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import com.halilibo.richtext.commonmark.CommonMarkdownParseOptions
 import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
 import com.halilibo.richtext.markdown.AstBlockNodeComposer
@@ -47,6 +51,8 @@ import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
+import com.halilibo.richtext.ui.string.InlineIconSpec
+import com.halilibo.richtext.ui.string.LinkInlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.LinkDecoration
 import com.halilibo.richtext.ui.string.RichTextDecorations
@@ -128,12 +134,21 @@ import com.halilibo.richtext.ui.string.UnderlineStyle
           val astNode = remember(parser) {
             parser.parse(sampleMarkdown)
           }
-          val richTextDecorations = remember {
+          val arrowPainter = rememberVectorPainter(Icons.Default.ArrowForward)
+          val linkTint = LocalContentColor.current
+          val richTextDecorations = remember(arrowPainter, linkTint) {
             RichTextDecorations(
               linkDecorations = listOf(
                 LinkDecoration(
                   matcher = { destination, _ -> destination.contains("dotted") },
                   underlineStyle = UnderlineStyle.Dotted(),
+                  inlineContent = LinkInlineContent(
+                    trailing = InlineIconSpec.Painter(
+                      painter = arrowPainter,
+                      tint = linkTint,
+                      contentDescription = null,
+                    ),
+                  ),
                 ),
                 LinkDecoration(
                   matcher = { destination, _ -> destination.contains("dashed") },

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
@@ -28,7 +28,7 @@ public data class RichTextDecorations(
 public data class LinkInlineContent(
   val leading: InlineIconSpec? = null,
   val trailing: InlineIconSpec? = null,
-  val spacing: Dp = 4.dp,
+  val spacing: Dp = 2.dp,
   val includeInHitTarget: Boolean = true,
 )
 
@@ -57,7 +57,7 @@ public sealed class InlineIconSpec(
   )
 
   public companion object {
-    public val DefaultSize: DpSize = DpSize(16.dp, 16.dp)
+    public val DefaultSize: DpSize = DpSize(24.dp, 24.dp)
     public val DefaultPlaceholderVerticalAlign: PlaceholderVerticalAlign =
       PlaceholderVerticalAlign.Center
   }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
@@ -40,8 +40,8 @@ public sealed class InlineIconSpec(
     val painter: androidx.compose.ui.graphics.painter.Painter,
     val tint: Color? = null,
     val contentDescription: String? = null,
-    val iconSize: DpSize = DefaultIconSize,
-    val iconPlaceholderVerticalAlign: PlaceholderVerticalAlign = PlaceholderVerticalAlign.Center,
+    val iconSize: DpSize = DefaultSize,
+    val iconPlaceholderVerticalAlign: PlaceholderVerticalAlign = DefaultPlaceholderVerticalAlign,
   ) : InlineIconSpec(
     size = iconSize,
     placeholderVerticalAlign = iconPlaceholderVerticalAlign,
@@ -49,12 +49,18 @@ public sealed class InlineIconSpec(
 
   public data class Composable(
     val content: LinkComposableContent,
-    val iconSize: DpSize = DefaultIconSize,
-    val iconPlaceholderVerticalAlign: PlaceholderVerticalAlign = PlaceholderVerticalAlign.Center,
+    val iconSize: DpSize = DefaultSize,
+    val iconPlaceholderVerticalAlign: PlaceholderVerticalAlign = DefaultPlaceholderVerticalAlign,
   ) : InlineIconSpec(
     size = iconSize,
     placeholderVerticalAlign = iconPlaceholderVerticalAlign,
   )
+
+  public companion object {
+    public val DefaultSize: DpSize = DpSize(16.dp, 16.dp)
+    public val DefaultPlaceholderVerticalAlign: PlaceholderVerticalAlign =
+      PlaceholderVerticalAlign.Center
+  }
 }
 
 public data class LinkContext(
@@ -85,5 +91,3 @@ public sealed class UnderlineStyle {
     val offset: Dp = 1.dp,
   ) : UnderlineStyle()
 }
-
-private val DefaultIconSize: DpSize = DpSize(16.dp, 16.dp)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
@@ -1,8 +1,12 @@
 package com.halilibo.richtext.ui.string
 
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 
 /**
  * Defines how specific links should be decorated based on their destination.
@@ -11,6 +15,7 @@ public data class LinkDecoration(
   val matcher: (destination: String, text: String) -> Boolean,
   val underlineStyle: UnderlineStyle = UnderlineStyle.Solid,
   val linkStyleOverride: ((TextLinkStyles?) -> TextLinkStyles)? = null,
+  val inlineContent: LinkInlineContent? = null,
 )
 
 /**
@@ -19,6 +24,47 @@ public data class LinkDecoration(
 public data class RichTextDecorations(
   val linkDecorations: List<LinkDecoration> = emptyList(),
 )
+
+public data class LinkInlineContent(
+  val leading: InlineIconSpec? = null,
+  val trailing: InlineIconSpec? = null,
+  val spacing: Dp = 4.dp,
+  val includeInHitTarget: Boolean = true,
+)
+
+public sealed class InlineIconSpec(
+  public val size: DpSize,
+  public val placeholderVerticalAlign: PlaceholderVerticalAlign,
+) {
+  public data class Painter(
+    val painter: androidx.compose.ui.graphics.painter.Painter,
+    val tint: Color? = null,
+    val contentDescription: String? = null,
+    val iconSize: DpSize = DefaultIconSize,
+    val iconPlaceholderVerticalAlign: PlaceholderVerticalAlign = PlaceholderVerticalAlign.Center,
+  ) : InlineIconSpec(
+    size = iconSize,
+    placeholderVerticalAlign = iconPlaceholderVerticalAlign,
+  )
+
+  public data class Composable(
+    val content: LinkComposableContent,
+    val iconSize: DpSize = DefaultIconSize,
+    val iconPlaceholderVerticalAlign: PlaceholderVerticalAlign = PlaceholderVerticalAlign.Center,
+  ) : InlineIconSpec(
+    size = iconSize,
+    placeholderVerticalAlign = iconPlaceholderVerticalAlign,
+  )
+}
+
+public data class LinkContext(
+  val destination: String,
+  val text: String,
+)
+
+public fun interface LinkComposableContent {
+  @Composable public fun Render(context: LinkContext)
+}
 
 /**
  * The underline style to use for a matched link.
@@ -39,3 +85,5 @@ public sealed class UnderlineStyle {
     val offset: Dp = 1.dp,
   ) : UnderlineStyle()
 }
+
+private val DefaultIconSize: DpSize = DpSize(16.dp, 16.dp)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkInlineDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkInlineDecorations.kt
@@ -1,0 +1,176 @@
+package com.halilibo.richtext.ui.string
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+internal data class DecoratedTextResult(
+  val annotatedString: AnnotatedString,
+  val inlineContents: Map<String, InlineContent>,
+  val decoratedLinkRanges: List<DecoratedLinkRange>,
+)
+
+internal fun ResolvedLinkDecorationRange.hasInlineContent(): Boolean {
+  val inlineContent = inlineContent ?: return false
+  return inlineContent.leading != null || inlineContent.trailing != null
+}
+
+internal fun decorateAnnotatedStringWithLinkIcons(
+  annotated: AnnotatedString,
+  baseInlineContents: Map<String, InlineContent>,
+  linkDecorations: List<ResolvedLinkDecorationRange>,
+): DecoratedTextResult {
+  if (linkDecorations.isEmpty()) {
+    return DecoratedTextResult(
+      annotatedString = annotated,
+      inlineContents = baseInlineContents,
+      decoratedLinkRanges = emptyList(),
+    )
+  }
+
+  val builder = AnnotatedString.Builder()
+  val inlineContents = LinkedHashMap<String, InlineContent>(baseInlineContents.size)
+  inlineContents.putAll(baseInlineContents)
+  val decoratedLinkRanges = mutableListOf<DecoratedLinkRange>()
+  val sortedDecorations = linkDecorations.sortedBy { it.start }
+  var cursor = 0
+
+  sortedDecorations.forEachIndexed { index, decoration ->
+    val start = decoration.start
+    val end = decoration.end
+    if (cursor < start) {
+      builder.append(annotated, cursor, start)
+    }
+    if (start >= end) {
+      cursor = maxOf(cursor, end)
+      return@forEachIndexed
+    }
+
+    val inlineContent = decoration.inlineContent
+    val linkAnnotation = annotated.getLinkAnnotations(start, end)
+      .firstOrNull()
+      ?.item as? LinkAnnotation.Url
+    if (inlineContent != null) {
+      inlineContent.leading?.let { spec ->
+        val id = "link_inline_${index}_leading"
+        builder.appendInlineContent(id, REPLACEMENT_CHAR)
+        inlineContents[id] = buildInlineContent(
+          spec = spec,
+          context = LinkContext(decoration.destination, decoration.text),
+          spacing = inlineContent.spacing,
+          isLeading = true,
+        )
+        if (inlineContent.includeInHitTarget && linkAnnotation != null) {
+          val iconStart = builder.length - 1
+          builder.addLink(linkAnnotation, iconStart, builder.length)
+        }
+      }
+    }
+
+    val textStart = builder.length
+    builder.append(annotated, start, end)
+    val textEnd = builder.length
+
+    if (inlineContent != null) {
+      inlineContent.trailing?.let { spec ->
+        val id = "link_inline_${index}_trailing"
+        builder.appendInlineContent(id, REPLACEMENT_CHAR)
+        inlineContents[id] = buildInlineContent(
+          spec = spec,
+          context = LinkContext(decoration.destination, decoration.text),
+          spacing = inlineContent.spacing,
+          isLeading = false,
+        )
+        if (inlineContent.includeInHitTarget && linkAnnotation != null) {
+          val iconStart = builder.length - 1
+          builder.addLink(linkAnnotation, iconStart, builder.length)
+        }
+      }
+    }
+
+    if (decoration.underlineStyle !is UnderlineStyle.Solid) {
+      decoratedLinkRanges += DecoratedLinkRange(
+        start = textStart,
+        end = textEnd,
+        destination = decoration.destination,
+        underlineStyle = decoration.underlineStyle,
+        linkStyleOverride = decoration.linkStyleOverride,
+      )
+    }
+
+    cursor = end
+  }
+
+  if (cursor < annotated.length) {
+    builder.append(annotated, cursor, annotated.length)
+  }
+
+  return DecoratedTextResult(
+    annotatedString = builder.toAnnotatedString(),
+    inlineContents = inlineContents,
+    decoratedLinkRanges = decoratedLinkRanges,
+  )
+}
+
+private fun buildInlineContent(
+  spec: InlineIconSpec,
+  context: LinkContext,
+  spacing: Dp,
+  isLeading: Boolean,
+): InlineContent {
+  val spacingWidth = if (spacing.value > 0f) spacing else 0.dp
+  val placeholderSize = if (spacingWidth.value > 0f) {
+    DpSize(
+      width = spec.size.width + spacingWidth,
+      height = spec.size.height,
+    )
+  } else {
+    spec.size
+  }
+
+  val paddingModifier = when {
+    spacingWidth.value <= 0f -> Modifier
+    isLeading -> Modifier.padding(end = spacingWidth)
+    else -> Modifier.padding(start = spacingWidth)
+  }
+
+  val contentModifier = paddingModifier
+    .then(Modifier.size(spec.size))
+
+  return InlineContent(
+    initialSize = {
+      IntSize(
+        placeholderSize.width.toPx().roundToInt(),
+        placeholderSize.height.toPx().roundToInt(),
+      )
+    },
+    placeholderVerticalAlign = spec.placeholderVerticalAlign,
+  ) {
+    when (spec) {
+      is InlineIconSpec.Painter -> {
+        Image(
+          painter = spec.painter,
+          contentDescription = spec.contentDescription,
+          colorFilter = spec.tint?.let { ColorFilter.tint(it) },
+          modifier = contentModifier,
+        )
+      }
+      is InlineIconSpec.Composable -> {
+        Box(modifier = contentModifier) {
+          spec.content.Render(context)
+        }
+      }
+    }
+  }
+}

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -16,15 +16,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.LinearGradientShader
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shader
@@ -32,17 +27,12 @@ import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.layout
-import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import com.halilibo.richtext.ui.RichTextScope
@@ -55,7 +45,6 @@ import com.halilibo.richtext.ui.util.segmentIntoPhrases
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.pow
-import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -213,166 +202,6 @@ private data class UnderlineSpec(
   val range: DecoratedLinkRange,
   val color: Color,
 )
-
-private data class DecoratedTextResult(
-  val annotatedString: AnnotatedString,
-  val inlineContents: Map<String, InlineContent>,
-  val decoratedLinkRanges: List<DecoratedLinkRange>,
-)
-
-private fun ResolvedLinkDecorationRange.hasInlineContent(): Boolean {
-  val inlineContent = inlineContent ?: return false
-  return inlineContent.leading != null || inlineContent.trailing != null
-}
-
-private fun decorateAnnotatedStringWithLinkIcons(
-  annotated: AnnotatedString,
-  baseInlineContents: Map<String, InlineContent>,
-  linkDecorations: List<ResolvedLinkDecorationRange>,
-): DecoratedTextResult {
-  if (linkDecorations.isEmpty()) {
-    return DecoratedTextResult(
-      annotatedString = annotated,
-      inlineContents = baseInlineContents,
-      decoratedLinkRanges = emptyList(),
-    )
-  }
-
-  val builder = AnnotatedString.Builder()
-  val inlineContents = LinkedHashMap<String, InlineContent>(baseInlineContents.size)
-  inlineContents.putAll(baseInlineContents)
-  val decoratedLinkRanges = mutableListOf<DecoratedLinkRange>()
-  val sortedDecorations = linkDecorations.sortedBy { it.start }
-  var cursor = 0
-
-  sortedDecorations.forEachIndexed { index, decoration ->
-    val start = decoration.start
-    val end = decoration.end
-    if (cursor < start) {
-      builder.append(annotated, cursor, start)
-    }
-    if (start >= end) {
-      cursor = maxOf(cursor, end)
-      return@forEachIndexed
-    }
-
-    val inlineContent = decoration.inlineContent
-    val linkAnnotation = annotated.getLinkAnnotations(start, end)
-      .firstOrNull()
-      ?.item as? LinkAnnotation.Url
-    if (inlineContent != null) {
-      inlineContent.leading?.let { spec ->
-        val id = "link_inline_${index}_leading"
-        builder.appendInlineContent(id, REPLACEMENT_CHAR)
-        inlineContents[id] = buildInlineContent(
-          spec = spec,
-          context = LinkContext(decoration.destination, decoration.text),
-          spacing = inlineContent.spacing,
-          isLeading = true,
-        )
-        if (inlineContent.includeInHitTarget && linkAnnotation != null) {
-          val iconStart = builder.length - 1
-          builder.addLink(linkAnnotation, iconStart, builder.length)
-        }
-      }
-    }
-
-    val textStart = builder.length
-    builder.append(annotated, start, end)
-    val textEnd = builder.length
-
-    if (inlineContent != null) {
-      inlineContent.trailing?.let { spec ->
-        val id = "link_inline_${index}_trailing"
-        builder.appendInlineContent(id, REPLACEMENT_CHAR)
-        inlineContents[id] = buildInlineContent(
-          spec = spec,
-          context = LinkContext(decoration.destination, decoration.text),
-          spacing = inlineContent.spacing,
-          isLeading = false,
-        )
-        if (inlineContent.includeInHitTarget && linkAnnotation != null) {
-          val iconStart = builder.length - 1
-          builder.addLink(linkAnnotation, iconStart, builder.length)
-        }
-      }
-    }
-
-    if (decoration.underlineStyle !is UnderlineStyle.Solid) {
-      decoratedLinkRanges += DecoratedLinkRange(
-        start = textStart,
-        end = textEnd,
-        destination = decoration.destination,
-        underlineStyle = decoration.underlineStyle,
-        linkStyleOverride = decoration.linkStyleOverride,
-      )
-    }
-
-    cursor = end
-  }
-
-  if (cursor < annotated.length) {
-    builder.append(annotated, cursor, annotated.length)
-  }
-
-  return DecoratedTextResult(
-    annotatedString = builder.toAnnotatedString(),
-    inlineContents = inlineContents,
-    decoratedLinkRanges = decoratedLinkRanges,
-  )
-}
-
-private fun buildInlineContent(
-  spec: InlineIconSpec,
-  context: LinkContext,
-  spacing: Dp,
-  isLeading: Boolean,
-): InlineContent {
-  val spacingWidth = if (spacing.value > 0f) spacing else 0.dp
-  val placeholderSize = if (spacingWidth.value > 0f) {
-    DpSize(
-      width = spec.size.width + spacingWidth,
-      height = spec.size.height,
-    )
-  } else {
-    spec.size
-  }
-
-  val paddingModifier = when {
-    spacingWidth.value <= 0f -> Modifier
-    isLeading -> Modifier.padding(end = spacingWidth)
-    else -> Modifier.padding(start = spacingWidth)
-  }
-
-  val contentModifier = paddingModifier
-    .then(Modifier.size(spec.size))
-
-  return InlineContent(
-    initialSize = {
-      IntSize(
-        placeholderSize.width.toPx().roundToInt(),
-        placeholderSize.height.toPx().roundToInt(),
-      )
-    },
-    placeholderVerticalAlign = spec.placeholderVerticalAlign,
-  ) {
-    when (spec) {
-      is InlineIconSpec.Painter -> {
-        Image(
-          painter = spec.painter,
-          contentDescription = spec.contentDescription,
-          colorFilter = spec.tint?.let { ColorFilter.tint(it) },
-          modifier = contentModifier,
-        )
-      }
-      is InlineIconSpec.Composable -> {
-        Box(modifier = contentModifier) {
-          spec.content.Render(context)
-        }
-      }
-    }
-  }
-}
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawUnderline(
   layoutResult: TextLayoutResult,

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -45,6 +45,7 @@ import com.halilibo.richtext.ui.util.segmentIntoPhrases
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.pow
+import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.milliseconds
 
 /**

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -16,10 +16,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.LinearGradientShader
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shader
@@ -27,12 +32,17 @@ import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.layout
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import com.halilibo.richtext.ui.RichTextScope
@@ -74,10 +84,45 @@ public fun RichTextScope.Text(
   val annotated = remember(text, resolvedStyle, contentColor, decorations) {
     text.toAnnotatedString(resolvedStyle, contentColor, decorations)
   }
-  val inlineContents = remember(text) { text.getInlineContents() }
-  val decoratedLinkRanges = remember(text, decorations) {
-    text.decoratedLinkRanges(decorations)
+  val baseInlineContents = remember(text) { text.getInlineContents() }
+  val resolvedLinkDecorations = remember(text, decorations) {
+    text.resolveLinkDecorations(decorations)
   }
+  val hasInlineIcons = remember(resolvedLinkDecorations) {
+    resolvedLinkDecorations.any { it.hasInlineContent() }
+  }
+  val decoratedTextResult = remember(
+    annotated,
+    baseInlineContents,
+    resolvedLinkDecorations,
+    hasInlineIcons,
+  ) {
+    if (hasInlineIcons) {
+      decorateAnnotatedStringWithLinkIcons(
+        annotated = annotated,
+        baseInlineContents = baseInlineContents,
+        linkDecorations = resolvedLinkDecorations,
+      )
+    } else {
+      DecoratedTextResult(
+        annotatedString = annotated,
+        inlineContents = baseInlineContents,
+        decoratedLinkRanges = resolvedLinkDecorations
+          .filter { it.underlineStyle !is UnderlineStyle.Solid }
+          .map { range ->
+            DecoratedLinkRange(
+              start = range.start,
+              end = range.end,
+              destination = range.destination,
+              underlineStyle = range.underlineStyle,
+              linkStyleOverride = range.linkStyleOverride,
+            )
+          },
+      )
+    }
+  }
+  val inlineContents = decoratedTextResult.inlineContents
+  val decoratedLinkRanges = decoratedTextResult.decoratedLinkRanges
   var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
   val underlineSpecs = remember(decoratedLinkRanges, resolvedStyle, contentColor) {
     decoratedLinkRanges.mapNotNull { range ->
@@ -113,14 +158,14 @@ public fun RichTextScope.Text(
 
   val animatedText = if (renderOptions.animate && inlineContents.isEmpty()) {
     rememberAnimatedText(
-      annotated = annotated,
+      annotated = decoratedTextResult.annotatedString,
       contentColor = contentColor,
       renderOptions = renderOptions,
       isLeafText = isLeafText,
       sharedAnimationState = sharedAnimationState,
     )
   } else {
-    annotated
+    decoratedTextResult.annotatedString
   }
 
   if (inlineContents.isEmpty()) {
@@ -168,6 +213,166 @@ private data class UnderlineSpec(
   val range: DecoratedLinkRange,
   val color: Color,
 )
+
+private data class DecoratedTextResult(
+  val annotatedString: AnnotatedString,
+  val inlineContents: Map<String, InlineContent>,
+  val decoratedLinkRanges: List<DecoratedLinkRange>,
+)
+
+private fun ResolvedLinkDecorationRange.hasInlineContent(): Boolean {
+  val inlineContent = inlineContent ?: return false
+  return inlineContent.leading != null || inlineContent.trailing != null
+}
+
+private fun decorateAnnotatedStringWithLinkIcons(
+  annotated: AnnotatedString,
+  baseInlineContents: Map<String, InlineContent>,
+  linkDecorations: List<ResolvedLinkDecorationRange>,
+): DecoratedTextResult {
+  if (linkDecorations.isEmpty()) {
+    return DecoratedTextResult(
+      annotatedString = annotated,
+      inlineContents = baseInlineContents,
+      decoratedLinkRanges = emptyList(),
+    )
+  }
+
+  val builder = AnnotatedString.Builder()
+  val inlineContents = LinkedHashMap<String, InlineContent>(baseInlineContents.size)
+  inlineContents.putAll(baseInlineContents)
+  val decoratedLinkRanges = mutableListOf<DecoratedLinkRange>()
+  val sortedDecorations = linkDecorations.sortedBy { it.start }
+  var cursor = 0
+
+  sortedDecorations.forEachIndexed { index, decoration ->
+    val start = decoration.start
+    val end = decoration.end
+    if (cursor < start) {
+      builder.append(annotated, cursor, start)
+    }
+    if (start >= end) {
+      cursor = maxOf(cursor, end)
+      return@forEachIndexed
+    }
+
+    val inlineContent = decoration.inlineContent
+    val linkAnnotation = annotated.getLinkAnnotations(start, end)
+      .firstOrNull()
+      ?.item as? LinkAnnotation.Url
+    if (inlineContent != null) {
+      inlineContent.leading?.let { spec ->
+        val id = "link_inline_${index}_leading"
+        builder.appendInlineContent(id, REPLACEMENT_CHAR)
+        inlineContents[id] = buildInlineContent(
+          spec = spec,
+          context = LinkContext(decoration.destination, decoration.text),
+          spacing = inlineContent.spacing,
+          isLeading = true,
+        )
+        if (inlineContent.includeInHitTarget && linkAnnotation != null) {
+          val iconStart = builder.length - 1
+          builder.addLink(linkAnnotation, iconStart, builder.length)
+        }
+      }
+    }
+
+    val textStart = builder.length
+    builder.append(annotated, start, end)
+    val textEnd = builder.length
+
+    if (inlineContent != null) {
+      inlineContent.trailing?.let { spec ->
+        val id = "link_inline_${index}_trailing"
+        builder.appendInlineContent(id, REPLACEMENT_CHAR)
+        inlineContents[id] = buildInlineContent(
+          spec = spec,
+          context = LinkContext(decoration.destination, decoration.text),
+          spacing = inlineContent.spacing,
+          isLeading = false,
+        )
+        if (inlineContent.includeInHitTarget && linkAnnotation != null) {
+          val iconStart = builder.length - 1
+          builder.addLink(linkAnnotation, iconStart, builder.length)
+        }
+      }
+    }
+
+    if (decoration.underlineStyle !is UnderlineStyle.Solid) {
+      decoratedLinkRanges += DecoratedLinkRange(
+        start = textStart,
+        end = textEnd,
+        destination = decoration.destination,
+        underlineStyle = decoration.underlineStyle,
+        linkStyleOverride = decoration.linkStyleOverride,
+      )
+    }
+
+    cursor = end
+  }
+
+  if (cursor < annotated.length) {
+    builder.append(annotated, cursor, annotated.length)
+  }
+
+  return DecoratedTextResult(
+    annotatedString = builder.toAnnotatedString(),
+    inlineContents = inlineContents,
+    decoratedLinkRanges = decoratedLinkRanges,
+  )
+}
+
+private fun buildInlineContent(
+  spec: InlineIconSpec,
+  context: LinkContext,
+  spacing: Dp,
+  isLeading: Boolean,
+): InlineContent {
+  val spacingWidth = if (spacing.value > 0f) spacing else 0.dp
+  val placeholderSize = if (spacingWidth.value > 0f) {
+    DpSize(
+      width = spec.size.width + spacingWidth,
+      height = spec.size.height,
+    )
+  } else {
+    spec.size
+  }
+
+  val paddingModifier = when {
+    spacingWidth.value <= 0f -> Modifier
+    isLeading -> Modifier.padding(end = spacingWidth)
+    else -> Modifier.padding(start = spacingWidth)
+  }
+
+  val contentModifier = paddingModifier
+    .then(Modifier.size(spec.size))
+
+  return InlineContent(
+    initialSize = {
+      IntSize(
+        placeholderSize.width.toPx().roundToInt(),
+        placeholderSize.height.toPx().roundToInt(),
+      )
+    },
+    placeholderVerticalAlign = spec.placeholderVerticalAlign,
+  ) {
+    when (spec) {
+      is InlineIconSpec.Painter -> {
+        Image(
+          painter = spec.painter,
+          contentDescription = spec.contentDescription,
+          colorFilter = spec.tint?.let { ColorFilter.tint(it) },
+          modifier = contentModifier,
+        )
+      }
+      is InlineIconSpec.Composable -> {
+        Box(modifier = contentModifier) {
+          spec.content.Render(context)
+        }
+      }
+    }
+  }
+}
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawUnderline(
   layoutResult: TextLayoutResult,


### PR DESCRIPTION
  ## Summary
  Add inline icon support to `LinkDecoration` (Painter + Composable) so links can render leading/trailing icons inline with text while preserving line‑wrap and underline behavior.
  Updates the Markdown demo to showcase the new capability.

  References: follow‑up to LinkDecoration groundwork in https://github.com/openai/compose-richtext/pull/49

  ## Changes
  - `LinkDecoration` now accepts `inlineContent` via `LinkInlineContent` (leading/trailing + spacing + hit target).
  - New `InlineIconSpec` sealed type with:
    - `Painter` (fast path for icons)
    - `Composable` (escape hatch for custom content)
  - New `LinkContext` and `LinkComposableContent` fun interface for composable content.
  - `RichTextString` now resolves link decorations into ranges that include link text.
  - `Text` builds a decorated `AnnotatedString` with inline placeholders and adjusts underline ranges accordingly.
  - Markdown demo shows a trailing arrow icon for dotted links.

  ## Behavior
  - Icons are inserted inline as placeholders, so they wrap naturally.
  - Underline drawing still respects line wrapping and excludes icons (underline stays on link text).
  - Optional `includeInHitTarget` expands link tap area to include the icons.

  ## RTL / Layout
  - Inline icons follow logical leading/trailing order, so they appear before/after the text in RTL appropriately.
  - Spacing uses `start/end` padding to respect layout direction.

  ## Testing
<img width="400" alt="image" src="https://github.com/user-attachments/assets/768d4d14-a524-4868-bd28-63fb879678f3" />


  ## Notes
  - `LinkDecoration.matcher` already supports `(destination, text)` so icon insertion can be context‑aware.
  - This is a middle‑ground API: efficient for common icon use cases while still allowing custom composables.

  ## Codex
  Prompt/context: “Add leading/trailing icon support to LinkDecoration using a middle‑ground API (Painter + Composable), integrate inline placeholders into `Text` so icons wrap with link
  text, keep underline drawing correct, and update the Markdown demo with an example.”
