### PR TITLE
True dots for dotted underline

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkDecorations.kt
@@ -80,9 +80,9 @@ public sealed class UnderlineStyle {
   public object Solid : UnderlineStyle()
 
   public data class Dotted(
-    val strokeWidth: Dp = 1.dp,
+    val strokeWidth: Dp = 2.dp,
     val gap: Dp = 2.dp,
-    val offset: Dp = 0.dp,
+    val offset: Dp = 0.5.dp,
   ) : UnderlineStyle()
 
   public data class Dashed(

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -239,8 +239,9 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawUnderline(
         strokeWidthPx = underlineStyle.strokeWidth.toPx()
         offsetPx = underlineStyle.offset.toPx()
         val gapPx = underlineStyle.gap.toPx()
-        val dotPx = strokeWidthPx.coerceAtLeast(1f)
-        pathEffect = PathEffect.dashPathEffect(floatArrayOf(dotPx, gapPx), 0f)
+        // Round-capped zero-length dashes render as true circular dots.
+        val patternGapPx = (gapPx + strokeWidthPx).coerceAtLeast(1f)
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(0f, patternGapPx), 0f)
         cap = StrokeCap.Round
       }
       is UnderlineStyle.Dashed -> {
@@ -265,7 +266,7 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawUnderline(
 
     val startBox = layoutResult.getBoundingBox(segmentStart)
     val endBox = layoutResult.getBoundingBox(segmentEnd - 1)
-    val y = (maxOf(startBox.bottom, endBox.bottom) + offsetPx).roundToInt().toFloat()
+    val y = layoutResult.getLineBaseline(line) + strokeWidthPx + offsetPx
     val xStart = startBox.left.roundToInt().toFloat()
     val xEnd = endBox.right.roundToInt().toFloat()
 


### PR DESCRIPTION
Tuning dotted underline so they are truly circular dots, also adjust the offset to account for baseline rather than bounding box.

<img width="365" height="189" alt="Screenshot 2026-02-04 at 10 11 11 AM" src="https://github.com/user-attachments/assets/0a8ddbd0-1599-47d1-bae1-c7a53bf3d649" />

🔽 

<img width="368" height="192" alt="Screenshot 2026-02-04 at 10 09 48 AM" src="https://github.com/user-attachments/assets/e4d2ec50-27f0-4c9f-9266-f47b50fc4fdd" />
