### PR TITLE
No newline between link and its decorations

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkInlineDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkInlineDecorations.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 
+private const val WORD_JOINER: String = "\u2060"
+
 internal data class DecoratedTextResult(
   val annotatedString: AnnotatedString,
   val inlineContents: Map<String, InlineContent>,
@@ -75,6 +77,8 @@ internal fun decorateAnnotatedStringWithLinkIcons(
           val iconStart = builder.length - 1
           builder.addLink(linkAnnotation, iconStart, builder.length)
         }
+        // Prevent the leading icon from wrapping onto a line by itself.
+        builder.append(WORD_JOINER)
       }
     }
 

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkInlineDecorations.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/LinkInlineDecorations.kt
@@ -88,6 +88,8 @@ internal fun decorateAnnotatedStringWithLinkIcons(
 
     if (inlineContent != null) {
       inlineContent.trailing?.let { spec ->
+        // Prevent the trailing icon from wrapping onto a line by itself.
+        builder.append(WORD_JOINER)
         val id = "link_inline_${index}_trailing"
         builder.appendInlineContent(id, REPLACEMENT_CHAR)
         inlineContents[id] = buildInlineContent(


### PR DESCRIPTION
Use non-breaking whitespace