### PR TITLE
Generated by Codex: Fix RTL markdown block alignment

### DIFF
--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.markdown.node.AstBlockQuote
@@ -72,17 +73,53 @@ internal fun RichTextScope.MarkdownRichText(
   val richText = remember(astNode) {
     computeRichTextString(astNode, inlineContentOverride)
   }
+  val fillBlockWidth = astNode.type is AstParagraph || astNode.type is AstHeading
+  val blockTextDirection = when {
+    fillBlockWidth -> firstStrongLetterLayoutDirection(richText.text)
+    else -> null
+  }
+  val textModifier = if (fillBlockWidth) {
+    modifier.fillMaxWidth()
+  } else {
+    modifier
+  }
 
   Text(
     text = richText,
-    modifier = modifier,
+    modifier = textModifier,
     isLeafText = astNode.isLastInTree(),
     renderOptions = richTextRenderOptions,
     sharedAnimationState = markdownAnimationState,
     decorations = richTextDecorations,
+    textAlign = when (blockTextDirection) {
+      TextDirection.Rtl -> androidx.compose.ui.text.style.TextAlign.Right
+      TextDirection.Ltr -> androidx.compose.ui.text.style.TextAlign.Left
+      else -> androidx.compose.ui.text.style.TextAlign.Start
+    },
+    textDirection = blockTextDirection,
   )
 }
 
+internal fun firstStrongLetterLayoutDirection(text: String): TextDirection? {
+  for (char in text) {
+    if (!char.isLetter()) continue
+
+    when (Character.getDirectionality(char)) {
+      Character.DIRECTIONALITY_RIGHT_TO_LEFT,
+      Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC,
+      Character.DIRECTIONALITY_RIGHT_TO_LEFT_EMBEDDING,
+      Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE,
+      -> return TextDirection.Rtl
+
+      Character.DIRECTIONALITY_LEFT_TO_RIGHT,
+      Character.DIRECTIONALITY_LEFT_TO_RIGHT_EMBEDDING,
+      Character.DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE,
+      -> return TextDirection.Ltr
+    }
+  }
+
+  return null
+}
 private fun AstNode?.isLastInTree(): Boolean = this?.links?.parent == null ||
     (links.next == null && links.parent.isLastInTree())
 

--- a/richtext-markdown/src/commonTest/kotlin/com/halilibo/richtext/markdown/MarkdownRichTextTest.kt
+++ b/richtext-markdown/src/commonTest/kotlin/com/halilibo/richtext/markdown/MarkdownRichTextTest.kt
@@ -1,0 +1,15 @@
+package com.halilibo.richtext.markdown
+
+import androidx.compose.ui.text.style.TextDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MarkdownRichTextTest {
+  @Test
+  fun `detects direction from the first strong letter`() {
+    assertEquals(TextDirection.Rtl, firstStrongLetterLayoutDirection("...שלום"))
+    assertEquals(TextDirection.Ltr, firstStrongLetterLayoutDirection("...hello"))
+    assertNull(firstStrongLetterLayoutDirection("...123"))
+  }
+}

--- a/richtext-ui/build.gradle.kts
+++ b/richtext-ui/build.gradle.kts
@@ -32,5 +32,11 @@ kotlin {
     val jvmMain by getting {
       kotlin.srcDir("src/commonJvmAndroid/kotlin")
     }
+    val jvmTest by getting {
+      kotlin.srcDir("src/jvmTest/kotlin")
+      dependencies {
+        implementation(Kotlin.Test.jdk)
+      }
+    }
   }
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -28,9 +28,12 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
@@ -65,6 +68,8 @@ public fun RichTextScope.Text(
   decorations: RichTextDecorations = RichTextDecorations(),
   overflow: TextOverflow = TextOverflow.Clip,
   maxLines: Int = Int.MAX_VALUE,
+  textAlign: TextAlign? = null,
+  textDirection: TextDirection? = null,
 ) {
   val style = currentRichTextStyle.stringStyle
   val contentColor = currentContentColor
@@ -142,6 +147,13 @@ public fun RichTextScope.Text(
     null
   }
   val animatedText = animatedResult?.text ?: decoratedTextResult.annotatedString
+  val paragraphStyledText = remember(animatedText, textAlign, textDirection) {
+    applyParagraphStyle(
+      text = animatedText,
+      textAlign = textAlign,
+      textDirection = textDirection,
+    )
+  }
   val underlineAlphaForOffset = animatedResult?.alphaForOffset
 
   val underlineModifier = if (underlineSpecs.isNotEmpty()) {
@@ -165,7 +177,7 @@ public fun RichTextScope.Text(
 
   if (inlineContents.isEmpty()) {
     Text(
-      text = animatedText,
+      text = paragraphStyledText,
       onTextLayout = { layoutResult ->
         textLayoutResult = layoutResult
         onTextLayout(layoutResult)
@@ -183,7 +195,7 @@ public fun RichTextScope.Text(
     )
 
     Text(
-      text = animatedText,
+      text = paragraphStyledText,
       onTextLayout = { layoutResult ->
         textLayoutResult = layoutResult
         onTextLayout(layoutResult)
@@ -201,6 +213,24 @@ public fun RichTextScope.Text(
         }
       },
     )
+  }
+}
+
+internal fun applyParagraphStyle(
+  text: AnnotatedString,
+  textAlign: TextAlign?,
+  textDirection: TextDirection?,
+): AnnotatedString {
+  if (textAlign == null && textDirection == null) return text
+
+  val paragraphStyle = ParagraphStyle(
+    textAlign = textAlign ?: TextAlign.Unspecified,
+    textDirection = textDirection ?: TextDirection.Unspecified,
+  )
+
+  return buildAnnotatedString {
+    append(text)
+    addStyle(paragraphStyle, 0, text.length)
   }
 }
 

--- a/richtext-ui/src/jvmTest/kotlin/com/halilibo/richtext/ui/string/TextTest.kt
+++ b/richtext-ui/src/jvmTest/kotlin/com/halilibo/richtext/ui/string/TextTest.kt
@@ -1,0 +1,34 @@
+package com.halilibo.richtext.ui.string
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class TextTest {
+  @Test
+  fun `applies paragraph style only when needed`() {
+    val text = AnnotatedString("שלום")
+    assertEquals(
+      listOf(
+        AnnotatedString.Range(
+          item = ParagraphStyle(
+            textAlign = TextAlign.Right,
+            textDirection = TextDirection.Rtl,
+          ),
+          start = 0,
+          end = text.length,
+        ),
+      ),
+      applyParagraphStyle(
+        text = text,
+        textAlign = TextAlign.Right,
+        textDirection = TextDirection.Rtl,
+      ).paragraphStyles,
+    )
+    assertSame(text, applyParagraphStyle(text = text, textAlign = null, textDirection = null))
+  }
+}


### PR DESCRIPTION
Generated by Codex:

Stacked on #59.

## Summary
- detect paragraph and heading direction from the first strong letter in markdown output
- pass paragraph alignment and direction into rich text rendering so RTL markdown blocks align correctly
- add regression coverage for direction detection and paragraph styling

## Testing
- `./gradlew build`