### PR TITLE
Generated by Codex: Modernize CI workflows and markdown test deps

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,15 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/actions/wrapper-validation@v3
+      - uses: actions/checkout@v6
       - name: set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 21
-      - uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ hashFiles('buildSrc/**') }}-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: gradle-${{ runner.os }}-
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,13 +13,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 21
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
+      - uses: gradle/actions/setup-gradle@v4
       - name: Install dependencies
         run: pip install mkdocs-material
       - name: Generate docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,17 +10,13 @@ jobs:
     name: Release build and publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/actions/wrapper-validation@v3
+      - uses: actions/checkout@v6
       - name: set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 17
-      - uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ hashFiles('buildSrc/**') }}-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: gradle-${{ runner.os }}-
+      - uses: gradle/actions/setup-gradle@v4
       - name: Release build
         run: ./gradlew :build
       - name: Publish to MavenCentral

--- a/richtext-markdown/build.gradle.kts
+++ b/richtext-markdown/build.gradle.kts
@@ -23,12 +23,22 @@ kotlin {
         api(project(":richtext-ui"))
       }
     }
-    val commonTest by getting
+    val commonTest by getting {
+      dependencies {
+        implementation(Kotlin.Test.common)
+        implementation(Kotlin.Test.annotations)
+      }
+    }
 
     val androidMain by getting {
       dependencies {
         implementation(Compose.coil)
         implementation(Compose.coilHttp)
+      }
+    }
+    val androidUnitTest by getting {
+      dependencies {
+        implementation(Kotlin.Test.jdk)
       }
     }
 


### PR DESCRIPTION
Generated by Codex:

## Summary
- upgrade GitHub workflows to current checkout/setup actions and `gradle/actions/setup-gradle@v4`
- remove the standalone Gradle cache and wrapper-validation steps in favor of the maintained setup action
- add the missing markdown multiplatform test dependencies so the new `commonTest` file builds on Android unit tests

## Testing
- `./gradlew :richtext-markdown:compileDebugUnitTestKotlinAndroid :richtext-markdown:compileReleaseUnitTestKotlinAndroid :richtext-markdown:jvmTest`
- `./gradlew build`