### PR TITLE
Add RTL compatibility sample previews

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -207,6 +207,20 @@ private val markdownCases = listOf(
     """.trimIndent(),
   ),
   MarkdownCase(
+    title = "Inline styling and code blocks",
+    markdown = """
+      This sentence includes `fixed width` text in the middle.
+
+      This sentence makes one word **bold** for emphasis.
+
+      ```kotlin
+      val english = "Hello"
+      val hebrew = "שלום"
+      println(english + " / " + hebrew)
+      ```
+    """.trimIndent(),
+  ),
+  MarkdownCase(
     title = "HTML alignment blocks",
     markdown = """
       <p align="left">Left aligned English block.</p>

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -1,0 +1,123 @@
+package com.zachklipp.richtext.sample
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.halilibo.richtext.commonmark.Markdown
+import com.halilibo.richtext.ui.material3.RichText
+
+@Preview(widthDp = 420, heightDp = 1000, showBackground = true)
+@Composable
+private fun RtlCompatibilityLtrPreview() {
+  SampleTheme {
+    Surface {
+      RtlCompatibilitySample(layoutDirection = LayoutDirection.Ltr)
+    }
+  }
+}
+
+@Preview(widthDp = 420, heightDp = 1000, showBackground = true)
+@Composable
+private fun RtlCompatibilityRtlPreview() {
+  SampleTheme {
+    Surface {
+      RtlCompatibilitySample(layoutDirection = LayoutDirection.Rtl)
+    }
+  }
+}
+
+@Composable
+fun RtlCompatibilitySample(
+  layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+) {
+  CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .verticalScroll(rememberScrollState())
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      Text(
+        text = if (layoutDirection == LayoutDirection.Rtl) "RTL UI" else "LTR UI",
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+      )
+      MarkdownCaseCard(
+        title = "English Content",
+        markdown = englishMarkdown,
+      )
+      MarkdownCaseCard(
+        title = "Hebrew Content",
+        markdown = hebrewMarkdown,
+      )
+    }
+  }
+}
+
+@Composable
+private fun MarkdownCaseCard(
+  title: String,
+  markdown: String,
+) {
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+    elevation = CardDefaults.elevatedCardElevation(),
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+      )
+      RichText(modifier = Modifier.fillMaxWidth()) {
+        Markdown(content = markdown)
+      }
+    }
+  }
+}
+
+private val englishMarkdown = """
+  # Title English
+
+  Text in English and then a [link](https://example.com) and more text.
+
+  A list with both languages:
+  1. English
+  2. עברית
+
+  <p align="right">Right</p>
+""".trimIndent()
+
+private val hebrewMarkdown = """
+  # כותרת בעברית
+
+  טקסט בעברית ואז [קישור](https://example.com) ועוד טקסט.
+
+  רשימה עם שתי השפות:
+  1. עברית
+  2. English
+
+  <p align="right">ימין</p>
+""".trimIndent()

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(name = "RTL Compatability Demo Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
+@Preview(name = "RTL Compatibility Demo Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
 @Composable
 private fun RtlCompatibilityNarrowPreview() {
   SampleTheme {
@@ -34,7 +34,7 @@ private fun RtlCompatibilityNarrowPreview() {
   }
 }
 
-@Preview(name = "RTL Compatability Demo Wide", widthDp = 960, heightDp = 1200, showBackground = true)
+@Preview(name = "RTL Compatibility Demo Wide", widthDp = 960, heightDp = 1200, showBackground = true)
 @Composable
 private fun RtlCompatibilityWidePreview() {
   SampleTheme {

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -1,15 +1,11 @@
 package com.zachklipp.richtext.sample
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -24,19 +20,9 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(name = "RTL Compatibility Demo Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
+@Preview(name = "RTL Compatibility Demo", widthDp = 412, heightDp = 2200, showBackground = true)
 @Composable
-private fun RtlCompatibilityNarrowPreview() {
-  SampleTheme {
-    Surface {
-      RtlCompatibilitySample()
-    }
-  }
-}
-
-@Preview(name = "RTL Compatibility Demo Wide", widthDp = 960, heightDp = 1200, showBackground = true)
-@Composable
-private fun RtlCompatibilityWidePreview() {
+private fun RtlCompatibilityPreview() {
   SampleTheme {
     Surface {
       RtlCompatibilitySample()
@@ -46,109 +32,68 @@ private fun RtlCompatibilityWidePreview() {
 
 @Composable
 fun RtlCompatibilitySample() {
-  BoxWithConstraints(
+  Column(
     modifier = Modifier
       .fillMaxWidth()
       .verticalScroll(rememberScrollState())
       .padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(24.dp),
   ) {
-    val isWideLayout = maxWidth >= 720.dp
+    Text(
+      text = "Compare the same markdown under LTR and RTL layout directions.",
+      style = MaterialTheme.typography.bodyLarge,
+    )
 
+    layoutDirectionPanels.forEach { panel ->
+      LayoutDirectionSection(
+        title = panel.title,
+        layoutDirection = panel.layoutDirection,
+      )
+    }
+  }
+}
+
+@Composable
+private fun LayoutDirectionSection(
+  title: String,
+  layoutDirection: LayoutDirection,
+) {
+  CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
     Column(
       modifier = Modifier.fillMaxWidth(),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
       Text(
-        text = "Compare the same markdown under LTR and RTL layout directions.",
-        style = MaterialTheme.typography.bodyLarge,
+        text = title,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
       )
-
-      if (isWideLayout) {
-        Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-          layoutDirectionPanels.forEach { panel ->
-            LayoutDirectionPanel(
-              title = panel.title,
-              layoutDirection = panel.layoutDirection,
-              modifier = Modifier.weight(1f),
-            )
-          }
-        }
-      } else {
-        Column(
-          modifier = Modifier.fillMaxWidth(),
-          verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-          layoutDirectionPanels.forEach { panel ->
-            LayoutDirectionPanel(
-              title = panel.title,
-              layoutDirection = panel.layoutDirection,
-            )
-          }
-        }
-      }
-    }
-  }
-}
-
-@Composable
-private fun LayoutDirectionPanel(
-  title: String,
-  layoutDirection: LayoutDirection,
-  modifier: Modifier = Modifier,
-) {
-  CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
-    Card(
-      modifier = modifier.fillMaxWidth(),
-      elevation = CardDefaults.elevatedCardElevation(),
-    ) {
-      Column(
-        modifier = Modifier
-          .fillMaxWidth()
-          .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-      ) {
-        Text(
-          text = title,
-          style = MaterialTheme.typography.headlineSmall,
-          fontWeight = FontWeight.Bold,
+      markdownCases.forEach { previewCase ->
+        MarkdownCaseSection(
+          title = previewCase.title,
+          markdown = previewCase.markdown,
         )
-        markdownCases.forEach { previewCase ->
-          MarkdownCaseCard(
-            title = previewCase.title,
-            markdown = previewCase.markdown,
-          )
-        }
       }
     }
   }
 }
 
 @Composable
-private fun MarkdownCaseCard(
+private fun MarkdownCaseSection(
   title: String,
   markdown: String,
 ) {
-  Card(
+  Column(
     modifier = Modifier.fillMaxWidth(),
-    elevation = CardDefaults.elevatedCardElevation(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
-    Column(
-      modifier = Modifier
-        .fillMaxWidth()
-        .padding(16.dp),
-      verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-      Text(
-        text = title,
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.SemiBold,
-      )
-      RichText(modifier = Modifier.fillMaxWidth()) {
-        Markdown(content = markdown)
-      }
+    Text(
+      text = title,
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.SemiBold,
+    )
+    RichText(modifier = Modifier.fillMaxWidth()) {
+      Markdown(content = markdown)
     }
   }
 }
@@ -165,11 +110,11 @@ private data class MarkdownCase(
 
 private val layoutDirectionPanels = listOf(
   LayoutDirectionPanelModel(
-    title = "LTR UI",
+    title = "LayoutDirection.Ltr",
     layoutDirection = LayoutDirection.Ltr,
   ),
   LayoutDirectionPanelModel(
-    title = "RTL UI",
+    title = "LayoutDirection.Rtl",
     layoutDirection = LayoutDirection.Rtl,
   ),
 )

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(name = "RTL Preview Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
+@Preview(name = "RTL Compatability Demo Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
 @Composable
 private fun RtlCompatibilityNarrowPreview() {
   SampleTheme {
@@ -34,7 +34,7 @@ private fun RtlCompatibilityNarrowPreview() {
   }
 }
 
-@Preview(name = "RTL Preview Wide", widthDp = 960, heightDp = 1200, showBackground = true)
+@Preview(name = "RTL Compatability Demo Wide", widthDp = 960, heightDp = 1200, showBackground = true)
 @Composable
 private fun RtlCompatibilityWidePreview() {
   SampleTheme {

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -1,7 +1,9 @@
 package com.zachklipp.richtext.sample
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -22,51 +24,104 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(widthDp = 420, heightDp = 1000, showBackground = true)
+@Preview(name = "RTL Matrix Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
 @Composable
-private fun RtlCompatibilityLtrPreview() {
+private fun RtlCompatibilityNarrowPreview() {
   SampleTheme {
     Surface {
-      RtlCompatibilitySample(layoutDirection = LayoutDirection.Ltr)
+      RtlCompatibilitySample()
     }
   }
 }
 
-@Preview(widthDp = 420, heightDp = 1000, showBackground = true)
+@Preview(name = "RTL Matrix Wide", widthDp = 960, heightDp = 1200, showBackground = true)
 @Composable
-private fun RtlCompatibilityRtlPreview() {
+private fun RtlCompatibilityWidePreview() {
   SampleTheme {
     Surface {
-      RtlCompatibilitySample(layoutDirection = LayoutDirection.Rtl)
+      RtlCompatibilitySample()
     }
   }
 }
 
 @Composable
-fun RtlCompatibilitySample(
-  layoutDirection: LayoutDirection = LayoutDirection.Ltr,
-) {
-  CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+fun RtlCompatibilitySample() {
+  BoxWithConstraints(
+    modifier = Modifier
+      .fillMaxWidth()
+      .verticalScroll(rememberScrollState())
+      .padding(16.dp),
+  ) {
+    val isWideLayout = maxWidth >= 720.dp
+
     Column(
-      modifier = Modifier
-        .fillMaxWidth()
-        .verticalScroll(rememberScrollState())
-        .padding(16.dp),
+      modifier = Modifier.fillMaxWidth(),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
       Text(
-        text = if (layoutDirection == LayoutDirection.Rtl) "RTL UI" else "LTR UI",
-        style = MaterialTheme.typography.headlineSmall,
-        fontWeight = FontWeight.Bold,
+        text = "Compare the same markdown under LTR and RTL layout directions.",
+        style = MaterialTheme.typography.bodyLarge,
       )
-      MarkdownCaseCard(
-        title = "English Content",
-        markdown = englishMarkdown,
-      )
-      MarkdownCaseCard(
-        title = "Hebrew Content",
-        markdown = hebrewMarkdown,
-      )
+
+      if (isWideLayout) {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+          layoutDirectionPanels.forEach { panel ->
+            LayoutDirectionPanel(
+              title = panel.title,
+              layoutDirection = panel.layoutDirection,
+              modifier = Modifier.weight(1f),
+            )
+          }
+        }
+      } else {
+        Column(
+          modifier = Modifier.fillMaxWidth(),
+          verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+          layoutDirectionPanels.forEach { panel ->
+            LayoutDirectionPanel(
+              title = panel.title,
+              layoutDirection = panel.layoutDirection,
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun LayoutDirectionPanel(
+  title: String,
+  layoutDirection: LayoutDirection,
+  modifier: Modifier = Modifier,
+) {
+  CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+    Card(
+      modifier = modifier.fillMaxWidth(),
+      elevation = CardDefaults.elevatedCardElevation(),
+    ) {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        Text(
+          text = title,
+          style = MaterialTheme.typography.headlineSmall,
+          fontWeight = FontWeight.Bold,
+        )
+        markdownCases.forEach { previewCase ->
+          MarkdownCaseCard(
+            title = previewCase.title,
+            markdown = previewCase.markdown,
+          )
+        }
+      }
     }
   }
 }
@@ -98,26 +153,64 @@ private fun MarkdownCaseCard(
   }
 }
 
-private val englishMarkdown = """
-  # Title English
+private data class LayoutDirectionPanelModel(
+  val title: String,
+  val layoutDirection: LayoutDirection,
+)
 
-  Text in English and then a [link](https://example.com) and more text.
+private data class MarkdownCase(
+  val title: String,
+  val markdown: String,
+)
 
-  A list with both languages:
-  1. English
-  2. עברית
+private val layoutDirectionPanels = listOf(
+  LayoutDirectionPanelModel(
+    title = "LTR UI",
+    layoutDirection = LayoutDirection.Ltr,
+  ),
+  LayoutDirectionPanelModel(
+    title = "RTL UI",
+    layoutDirection = LayoutDirection.Rtl,
+  ),
+)
 
-  <p align="right">Right</p>
-""".trimIndent()
+private val markdownCases = listOf(
+  MarkdownCase(
+    title = "English-first paragraph",
+    markdown = """
+      # English heading
 
-private val hebrewMarkdown = """
-  # כותרת בעברית
+      This paragraph starts in English, links to [example.com](https://example.com),
+      then mentions עברית before ending in English.
 
-  טקסט בעברית ואז [קישור](https://example.com) ועוד טקסט.
+      > English quote with a little עברית mixed in.
+    """.trimIndent(),
+  ),
+  MarkdownCase(
+    title = "Hebrew-first paragraph",
+    markdown = """
+      # כותרת בעברית
 
-  רשימה עם שתי השפות:
-  1. עברית
-  2. English
+      הפסקה הזאת מתחילה בעברית, מוסיפה [קישור](https://example.com),
+      ואז משלבת English לפני הסיום.
 
-  <p align="right">ימין</p>
-""".trimIndent()
+      > ציטוט בעברית עם English בפנים.
+    """.trimIndent(),
+  ),
+  MarkdownCase(
+    title = "Lists and nesting",
+    markdown = """
+      1. English item
+         - Nested עברית item
+      2. פריט בעברית
+         - Nested English item
+    """.trimIndent(),
+  ),
+  MarkdownCase(
+    title = "HTML alignment blocks",
+    markdown = """
+      <p align="left">Left aligned English block.</p>
+      <p align="right">בלוק מיושר לימין.</p>
+    """.trimIndent(),
+  ),
+)

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(name = "RTL Matrix Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
+@Preview(name = "RTL Preview Narrow", widthDp = 420, heightDp = 1600, showBackground = true)
 @Composable
 private fun RtlCompatibilityNarrowPreview() {
   SampleTheme {
@@ -34,7 +34,7 @@ private fun RtlCompatibilityNarrowPreview() {
   }
 }
 
-@Preview(name = "RTL Matrix Wide", widthDp = 960, heightDp = 1200, showBackground = true)
+@Preview(name = "RTL Preview Wide", widthDp = 960, heightDp = 1200, showBackground = true)
 @Composable
 private fun RtlCompatibilityWidePreview() {
   SampleTheme {

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -13,19 +13,46 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(name = "RTL Compatibility Demo", widthDp = 412, heightDp = 2200, showBackground = true)
+@Preview(name = "English Heading · en-US", locale = "en-rUS", widthDp = 412, heightDp = 915, showBackground = true)
+@Preview(name = "English Heading · he-IL", locale = "he-rIL", widthDp = 412, heightDp = 915, showBackground = true)
 @Composable
-private fun RtlCompatibilityPreview() {
+private fun EnglishHeadingPreview() {
+  PreviewCaseSurface {
+    MarkdownCaseContent(markdown = englishHeadingMarkdown)
+  }
+}
+
+@Preview(name = "כותרת בעברית · en-US", locale = "en-rUS", widthDp = 412, heightDp = 915, showBackground = true)
+@Preview(name = "כותרת בעברית · he-IL", locale = "he-rIL", widthDp = 412, heightDp = 915, showBackground = true)
+@Composable
+private fun HebrewHeadingPreview() {
+  PreviewCaseSurface {
+    MarkdownCaseContent(markdown = hebrewHeadingMarkdown)
+  }
+}
+
+@Preview(name = "Inline styling and code blocks · en-US", locale = "en-rUS", widthDp = 412, heightDp = 915, showBackground = true)
+@Preview(name = "Inline styling and code blocks · he-IL", locale = "he-rIL", widthDp = 412, heightDp = 915, showBackground = true)
+@Composable
+private fun InlineStylingAndCodeBlocksPreview() {
+  PreviewCaseSurface {
+    MarkdownCaseContent(markdown = inlineStylingAndCodeBlocksMarkdown)
+  }
+}
+
+@Composable
+private fun PreviewCaseSurface(
+  content: @Composable () -> Unit,
+) {
   SampleTheme {
     Surface {
-      RtlCompatibilitySample()
+      content()
     }
   }
 }
@@ -37,41 +64,13 @@ fun RtlCompatibilitySample() {
       .fillMaxWidth()
       .verticalScroll(rememberScrollState())
       .padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(24.dp),
+    verticalArrangement = Arrangement.spacedBy(28.dp),
   ) {
-    Text(
-      text = "Compare the same markdown under LTR and RTL layout directions.",
-      style = MaterialTheme.typography.bodyLarge,
-    )
-
-    layoutDirectionPanels.forEach { panel ->
-      LayoutDirectionSection(
-        title = panel.title,
-        layoutDirection = panel.layoutDirection,
-      )
-    }
-  }
-}
-
-@Composable
-private fun LayoutDirectionSection(
-  title: String,
-  layoutDirection: LayoutDirection,
-) {
-  CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
-    Column(
-      modifier = Modifier.fillMaxWidth(),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-      Text(
-        text = title,
-        style = MaterialTheme.typography.headlineSmall,
-        fontWeight = FontWeight.Bold,
-      )
-      markdownCases.forEach { previewCase ->
-        MarkdownCaseSection(
-          title = previewCase.title,
-          markdown = previewCase.markdown,
+    markdownCases.forEach { markdown ->
+      previewVariants.forEach { previewVariant ->
+        LocalizedMarkdownCaseSection(
+          markdown = markdown,
+          previewVariant = previewVariant,
         )
       }
     }
@@ -79,97 +78,89 @@ private fun LayoutDirectionSection(
 }
 
 @Composable
-private fun MarkdownCaseSection(
-  title: String,
+private fun LocalizedMarkdownCaseSection(
   markdown: String,
+  previewVariant: PreviewVariant,
+) {
+  CompositionLocalProvider(LocalLayoutDirection provides previewVariant.layoutDirection) {
+    MarkdownCaseContent(
+      localeLabel = previewVariant.localeLabel,
+      layoutDirection = previewVariant.layoutDirection,
+      markdown = markdown,
+    )
+  }
+}
+
+@Composable
+private fun MarkdownCaseContent(
+  markdown: String,
+  localeLabel: String? = null,
+  layoutDirection: LayoutDirection? = null,
 ) {
   Column(
     modifier = Modifier.fillMaxWidth(),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
-    Text(
-      text = title,
-      style = MaterialTheme.typography.titleMedium,
-      fontWeight = FontWeight.SemiBold,
-    )
+    if (localeLabel != null) {
+      Text(
+        text = "locale = $localeLabel",
+        style = MaterialTheme.typography.labelLarge,
+      )
+    }
+    if (layoutDirection != null) {
+      Text(
+        text = "layoutDirection = LayoutDirection.${layoutDirection.name}",
+        style = MaterialTheme.typography.labelLarge,
+      )
+    }
     RichText(modifier = Modifier.fillMaxWidth()) {
       Markdown(content = markdown)
     }
   }
 }
 
-private data class LayoutDirectionPanelModel(
-  val title: String,
+private data class PreviewVariant(
+  val localeLabel: String,
   val layoutDirection: LayoutDirection,
 )
 
-private data class MarkdownCase(
-  val title: String,
-  val markdown: String,
+private val previewVariants = listOf(
+  PreviewVariant(localeLabel = "en-US", layoutDirection = LayoutDirection.Ltr),
+  PreviewVariant(localeLabel = "he-IL", layoutDirection = LayoutDirection.Rtl),
 )
 
-private val layoutDirectionPanels = listOf(
-  LayoutDirectionPanelModel(
-    title = "LayoutDirection.Ltr",
-    layoutDirection = LayoutDirection.Ltr,
-  ),
-  LayoutDirectionPanelModel(
-    title = "LayoutDirection.Rtl",
-    layoutDirection = LayoutDirection.Rtl,
-  ),
-)
+private val englishHeadingMarkdown = """
+  # English Heading
+
+  This paragraph starts in English, links to [example.com](https://example.com),
+  then mentions עברית before ending in English.
+
+  > English quote with a little עברית mixed in.
+""".trimIndent()
+
+private val hebrewHeadingMarkdown = """
+  # כותרת בעברית
+
+  הפסקה הזאת מתחילה בעברית, מוסיפה [קישור](https://example.com),
+  ואז משלבת English לפני הסיום.
+
+  > ציטוט בעברית עם English בפנים.
+""".trimIndent()
+
+private val inlineStylingAndCodeBlocksMarkdown = """
+  This sentence includes `fixed width` text in the middle.
+
+  This sentence makes one word **bold** for emphasis.
+
+  ```kotlin
+  val english = "Hello"
+  val hebrew = "שלום"
+  println(english + " / " + hebrew)
+  ```
+""".trimIndent()
 
 private val markdownCases = listOf(
-  MarkdownCase(
-    title = "English-first paragraph",
-    markdown = """
-      # English heading
-
-      This paragraph starts in English, links to [example.com](https://example.com),
-      then mentions עברית before ending in English.
-
-      > English quote with a little עברית mixed in.
-    """.trimIndent(),
-  ),
-  MarkdownCase(
-    title = "Hebrew-first paragraph",
-    markdown = """
-      # כותרת בעברית
-
-      הפסקה הזאת מתחילה בעברית, מוסיפה [קישור](https://example.com),
-      ואז משלבת English לפני הסיום.
-
-      > ציטוט בעברית עם English בפנים.
-    """.trimIndent(),
-  ),
-  MarkdownCase(
-    title = "Lists and nesting",
-    markdown = """
-      1. English item
-         - Nested עברית item
-      2. פריט בעברית
-         - Nested English item
-    """.trimIndent(),
-  ),
-  MarkdownCase(
-    title = "Inline styling and code blocks",
-    markdown = """
-      This sentence includes `fixed width` text in the middle.
-
-      This sentence makes one word **bold** for emphasis.
-
-      ```kotlin
-      val english = "Hello"
-      val hebrew = "שלום"
-      println(english + " / " + hebrew)
-      ```
-    """.trimIndent(),
-  ),
-  MarkdownCase(
-    title = "HTML alignment blocks",
-    markdown = """
-      <p align="left">Left aligned English block.</p>
-      <p align="right">בלוק מיושר לימין.</p>
-    """.trimIndent(),
-  ),
+  englishHeadingMarkdown,
+  hebrewHeadingMarkdown,
+  inlineStylingAndCodeBlocksMarkdown,
 )

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   "RichText Demo" to @Composable { RichTextSample() },
   "Markdown Demo" to @Composable { MarkdownSample() },
-  "RTL Compatability Demo" to @Composable { RtlCompatibilitySample() },
+  "RTL Compatibility Demo" to @Composable { RtlCompatibilitySample() },
   "Lazy Markdown Demo" to @Composable { LazyMarkdownSample() },
   "Text Animation" to @Composable { AnimatedRichTextSample() },
   "Chinese Text Animation" to @Composable { ChineseAnimatedRichTextSample() },

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   "RichText Demo" to @Composable { RichTextSample() },
   "Markdown Demo" to @Composable { MarkdownSample() },
-  "RTL Preview" to @Composable { RtlCompatibilitySample() },
+  "RTL Compatability Demo" to @Composable { RtlCompatibilitySample() },
   "Lazy Markdown Demo" to @Composable { LazyMarkdownSample() },
   "Text Animation" to @Composable { AnimatedRichTextSample() },
   "Chinese Text Animation" to @Composable { ChineseAnimatedRichTextSample() },

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   "RichText Demo" to @Composable { RichTextSample() },
   "Markdown Demo" to @Composable { MarkdownSample() },
-  "RTL Compatibility Matrix" to @Composable { RtlCompatibilitySample() },
+  "RTL Preview" to @Composable { RtlCompatibilitySample() },
   "Lazy Markdown Demo" to @Composable { LazyMarkdownSample() },
   "Text Animation" to @Composable { AnimatedRichTextSample() },
   "Chinese Text Animation" to @Composable { ChineseAnimatedRichTextSample() },

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   "RichText Demo" to @Composable { RichTextSample() },
   "Markdown Demo" to @Composable { MarkdownSample() },
+  "RTL Compatibility Matrix" to @Composable { RtlCompatibilitySample() },
   "Lazy Markdown Demo" to @Composable { LazyMarkdownSample() },
   "Text Animation" to @Composable { AnimatedRichTextSample() },
   "Chinese Text Animation" to @Composable { ChineseAnimatedRichTextSample() },


### PR DESCRIPTION
Human: Adding these, all renders of RTL in a LTR context or vice versa are borked. So 3 of these screenshots look really bad, but this is a good first step to iterate on fixing these.

Codex: Adds a focused RTL compatibility demo to the Android sample with three rich text cases, each previewed in both `en-US` and `he-IL` locales.

## What changed
- replaces the earlier multi-case layout with three focused examples: English Heading, כותרת בעברית, and Inline styling and code blocks
- adds two `@Preview` annotations per example so each case renders in both `en-US` and `he-IL`
- simplifies the sample implementation by removing duplicated title rendering and extra preview-only helpers

## Screenshots
| Example | en-US | he-IL |
| --- | --- | --- |
| English header | <img width="320" alt="English Heading en-US" src="https://github.com/user-attachments/assets/d018ec6c-c23d-4962-be6f-01c0a9204c36" /> | <img width="320" alt="English Heading he-IL" src="https://github.com/user-attachments/assets/7fa38e21-1b72-4fc8-8065-dc2bc676285c" /> |
| Hebrew header | <img width="320" alt="כותרת בעברית en-US" src="https://github.com/user-attachments/assets/93347623-bb9d-43f7-8c1d-1df7199520a4" /> | <img width="320" alt="כותרת בעברית he-IL" src="https://github.com/user-attachments/assets/510a9419-0990-4973-9c3f-2f4898196bd4" /> |
| Inline styling and code blocks | <img width="320" alt="Inline styling and code blocks en-US" src="https://github.com/user-attachments/assets/b939887a-1c14-47d8-8870-a05ba52f1015" /> | <img width="320" alt="Inline styling and code blocks he-IL" src="https://github.com/user-attachments/assets/7de9d325-cced-4b32-8b85-08e2aebf7462" /> |

## Testing
- `./gradlew :android-sample:build`
- Installed `android-sample-debug.apk` on an emulator and captured six screenshots