### PR TITLE
Codex: Add Roborazzi preview screenshot generation

### DIFF
--- a/android-sample/build.gradle.kts
+++ b/android-sample/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -5,6 +6,7 @@ plugins {
   kotlin("android")
   id("org.jetbrains.compose") version Compose.desktopVersion
   id("org.jetbrains.kotlin.plugin.compose") version Kotlin.version
+  id("io.github.takahirom.roborazzi")
 }
 
 android {
@@ -24,6 +26,15 @@ android {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
   }
+
+  testOptions {
+    unitTests {
+      isIncludeAndroidResources = true
+      all { test ->
+        test.systemProperty("robolectric.pixelCopyRenderMode", "hardware")
+      }
+    }
+  }
 }
 
 kotlin {
@@ -41,4 +52,26 @@ dependencies {
   implementation(compose.materialIconsExtended)
   implementation(compose.material3)
   implementation(compose.uiTooling)
+
+  testImplementation("androidx.compose.ui:ui-test-junit4:1.8.2")
+  testImplementation("androidx.compose.ui:ui-test-manifest:1.8.2")
+  testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1")
+  testImplementation("io.github.takahirom.roborazzi:roborazzi:1.59.0")
+  testImplementation("io.github.takahirom.roborazzi:roborazzi-compose:1.59.0")
+  testImplementation("io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:1.59.0")
+  testImplementation("junit:junit:4.13.2")
+  testImplementation("org.robolectric:robolectric:4.16.1")
+}
+
+roborazzi {
+  @OptIn(ExperimentalRoborazziApi::class)
+  generateComposePreviewRobolectricTests {
+    enable = true
+    packages = listOf("com.zachklipp.richtext.sample")
+    includePrivatePreviews = true
+    robolectricConfig = mapOf(
+      "sdk" to "[36]",
+      "qualifiers" to "RobolectricDeviceQualifiers.Pixel5",
+    )
+  }
 }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -34,6 +34,7 @@ import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.Table
 import com.halilibo.richtext.ui.WithStyle
 import com.halilibo.richtext.ui.material3.RichText
+import com.halilibo.richtext.ui.resolveDefaults
 import com.halilibo.richtext.ui.string.LinkDecoration
 import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextString
@@ -62,9 +63,10 @@ import com.halilibo.richtext.ui.string.withFormat
   style: RichTextStyle? = null,
   header: String = ""
 ) {
+  val currentStyle = style?.resolveDefaults() ?: RichTextStyle().resolveDefaults()
   RichText(
     modifier = Modifier.padding(8.dp),
-    style = style
+    style = currentStyle
   ) {
     Heading(0, "Paragraphs $header")
     Text("Simple paragraph.")
@@ -166,7 +168,6 @@ import com.halilibo.richtext.ui.string.withFormat
       }
     }
 
-    val currentStyle = style!!
     WithStyle(
       currentStyle.copy(
         tableStyle = currentStyle.tableStyle!!.copy(

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
 import com.halilibo.richtext.ui.material3.RichText
 
-@Preview(name = "English Heading · en-US", locale = "en-rUS", widthDp = 412, heightDp = 915, showBackground = true)
-@Preview(name = "English Heading · he-IL", locale = "he-rIL", widthDp = 412, heightDp = 915, showBackground = true)
+@Preview(name = "English Heading · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "English Heading · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
 @Composable
 private fun EnglishHeadingPreview() {
   PreviewCaseSurface {
@@ -28,8 +28,8 @@ private fun EnglishHeadingPreview() {
   }
 }
 
-@Preview(name = "כותרת בעברית · en-US", locale = "en-rUS", widthDp = 412, heightDp = 915, showBackground = true)
-@Preview(name = "כותרת בעברית · he-IL", locale = "he-rIL", widthDp = 412, heightDp = 915, showBackground = true)
+@Preview(name = "כותרת בעברית · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "כותרת בעברית · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
 @Composable
 private fun HebrewHeadingPreview() {
   PreviewCaseSurface {
@@ -37,8 +37,8 @@ private fun HebrewHeadingPreview() {
   }
 }
 
-@Preview(name = "Inline styling and code blocks · en-US", locale = "en-rUS", widthDp = 412, heightDp = 915, showBackground = true)
-@Preview(name = "Inline styling and code blocks · he-IL", locale = "he-rIL", widthDp = 412, heightDp = 915, showBackground = true)
+@Preview(name = "Inline styling and code blocks · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "Inline styling and code blocks · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
 @Composable
 private fun InlineStylingAndCodeBlocksPreview() {
   PreviewCaseSurface {

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -54,7 +54,12 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
 
 @Preview(showBackground = true)
 @Composable private fun SampleLauncherPreview() {
-  SamplesListScreen(isDarkTheme = true, onSampleClicked = {}, onThemeToggleClicked = {})
+  SamplesListScreen(
+    isDarkTheme = true,
+    onSampleClicked = {},
+    onThemeToggleClicked = {},
+    showSamplePreviews = false,
+  )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -97,6 +102,7 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   isDarkTheme: Boolean,
   onSampleClicked: (Int) -> Unit,
   onThemeToggleClicked: () -> Unit,
+  showSamplePreviews: Boolean = true,
 ) {
   Scaffold(
     topBar = {
@@ -113,7 +119,11 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
         ListItem(
           headlineContent = { Text(title) },
           modifier = Modifier.clickable(onClick = { onSampleClicked(index) }),
-          leadingContent = { SamplePreview(sampleContent) }
+          leadingContent = if (showSamplePreviews) {
+            { SamplePreview(sampleContent) }
+          } else {
+            null
+          }
         )
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ buildscript {
 
 plugins {
   id("org.jetbrains.dokka") version "2.0.0"
+  id("io.github.takahirom.roborazzi") version "1.59.0" apply false
 }
 
 repositories {


### PR DESCRIPTION
Codex: This PR adds a reliable way to generate Compose preview screenshots from Gradle without launching the app manually.

## Summary
- add Roborazzi preview generation for `android-sample` previews
- include the preview scanner and Robolectric setup needed to render previews in unit tests
- fix two existing previews that were failing under generated screenshot tests
- keep the RTL compatibility screenshots compact by using a fixed width without an explicit height

## Testing
- `./gradlew :android-sample:recordRoborazziDebug`

This will render images such as:
<img width="1133" height="373" alt="english-heading-en-us" src="https://github.com/user-attachments/assets/2c85d856-3a08-4ccf-885b-231590a0421e" />
