### PR TITLE
Decouple RTL compatibility from width

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -1,6 +1,8 @@
 package com.zachklipp.richtext.sample
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
@@ -73,6 +76,30 @@ private fun CodeWidthBehaviorPreview() {
         title = "Symbols-only code keeps the same width",
         markdown = symbolsCodeMarkdown,
       )
+    }
+  }
+}
+
+@Preview(name = "Top-level width behavior · zh", locale = "zh", widthDp = 412, showBackground = true)
+@Composable
+private fun TopLevelWidthBehaviorPreview() {
+  SampleTheme {
+    Surface {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+      ) {
+        TopLevelWidthSection(
+          title = "English text stays shrink-wrapped in zh locale",
+          markdown = englishTopLevelMarkdown,
+        )
+        TopLevelWidthSection(
+          title = "Chinese text stays shrink-wrapped in zh locale",
+          markdown = chineseTopLevelMarkdown,
+        )
+      }
     }
   }
 }
@@ -154,6 +181,38 @@ private fun CodeComparisonSection(
 }
 
 @Composable
+private fun TopLevelWidthSection(
+  title: String,
+  markdown: String,
+) {
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.labelLarge,
+    )
+    Text(
+      text = "compatibility off",
+      style = MaterialTheme.typography.bodySmall,
+    )
+    ShrinkWrappedBehaviorMarkdown(
+      markdown = markdown,
+      enableRtlCompatibility = false,
+    )
+    Text(
+      text = "compatibility on",
+      style = MaterialTheme.typography.bodySmall,
+    )
+    ShrinkWrappedBehaviorMarkdown(
+      markdown = markdown,
+      enableRtlCompatibility = true,
+    )
+  }
+}
+
+@Composable
 private fun BehaviorMarkdown(
   markdown: String,
   enableRtlCompatibility: Boolean = true,
@@ -165,6 +224,27 @@ private fun BehaviorMarkdown(
         enableRtlCompatibility = enableRtlCompatibility,
       ),
     )
+  }
+}
+
+@Composable
+private fun ShrinkWrappedBehaviorMarkdown(
+  markdown: String,
+  enableRtlCompatibility: Boolean,
+) {
+  Box(
+    modifier = Modifier
+      .background(color = Color(0xFFE9E9E9))
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+  ) {
+    RichText {
+      Markdown(
+        content = markdown,
+        richtextRenderOptions = RichTextRenderOptions(
+          enableRtlCompatibility = enableRtlCompatibility,
+        ),
+      )
+    }
   }
 }
 
@@ -208,4 +288,12 @@ private val symbolsCodeMarkdown = """
   ```
   () [] {} <> / == -> ++
   ```
+""".trimIndent()
+
+private val englishTopLevelMarkdown = """
+  1:53 AM is the current time in Hong Kong.
+""".trimIndent()
+
+private val chineseTopLevelMarkdown = """
+  现在香港时间是凌晨 1:53。
 """.trimIndent()

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,20 +26,13 @@ import com.halilibo.richtext.ui.string.RichTextRenderOptions
 @Composable
 private fun QuoteBehaviorPreview() {
   BehaviorPreviewSurface {
-    BehaviorPreviewColumn {
-      BehaviorSection(
-        title = "English-starting quote keeps its gutter on the left",
-        markdown = englishStartingQuoteMarkdown,
-      )
-      BehaviorSection(
-        title = "Hebrew-starting quote keeps its gutter on the right",
-        markdown = hebrewStartingQuoteMarkdown,
-      )
-      BehaviorSection(
-        title = "Neutral quote falls back to the system side",
-        markdown = symbolsQuoteMarkdown,
-      )
-    }
+    BehaviorPreviewColumn(
+      markdownSections = listOf(
+        englishStartingQuoteMarkdown,
+        hebrewStartingQuoteMarkdown,
+        symbolsQuoteMarkdown,
+      ),
+    )
   }
 }
 
@@ -46,20 +40,13 @@ private fun QuoteBehaviorPreview() {
 @Composable
 private fun ListBehaviorPreview() {
   BehaviorPreviewSurface {
-    BehaviorPreviewColumn {
-      BehaviorSection(
-        title = "English first item keeps bullets on the left",
-        markdown = englishStartingListMarkdown,
-      )
-      BehaviorSection(
-        title = "Hebrew first item keeps bullets on the right",
-        markdown = hebrewStartingListMarkdown,
-      )
-      BehaviorSection(
-        title = "Neutral first item falls back to the system side",
-        markdown = neutralStartingListMarkdown,
-      )
-    }
+    BehaviorPreviewColumn(
+      markdownSections = listOf(
+        englishStartingListMarkdown,
+        hebrewStartingListMarkdown,
+        neutralStartingListMarkdown,
+      ),
+    )
   }
 }
 
@@ -132,19 +119,21 @@ private fun BehaviorPreviewColumn(
 }
 
 @Composable
-private fun BehaviorSection(
-  title: String,
-  markdown: String,
+private fun BehaviorPreviewColumn(
+  markdownSections: List<String>,
 ) {
   Column(
-    modifier = Modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(24.dp),
   ) {
-    Text(
-      text = title,
-      style = MaterialTheme.typography.labelLarge,
-    )
-    BehaviorMarkdown(markdown = markdown)
+    markdownSections.forEachIndexed { index, markdown ->
+      BehaviorMarkdown(markdown = markdown)
+      if (index != markdownSections.lastIndex) {
+        HorizontalDivider()
+      }
+    }
   }
 }
 
@@ -157,10 +146,8 @@ private fun CodeComparisonSection(
     modifier = Modifier.fillMaxWidth(),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
-    Text(
-      text = title,
-      style = MaterialTheme.typography.labelLarge,
-    )
+    BehaviorMarkdown(markdown = "### $title")
+    HorizontalDivider()
     Text(
       text = "compatibility off",
       style = MaterialTheme.typography.bodySmall,
@@ -169,6 +156,7 @@ private fun CodeComparisonSection(
       markdown = markdown,
       enableRtlCompatibility = false,
     )
+    HorizontalDivider()
     Text(
       text = "compatibility on",
       style = MaterialTheme.typography.bodySmall,
@@ -189,10 +177,8 @@ private fun TopLevelWidthSection(
     modifier = Modifier.fillMaxWidth(),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
-    Text(
-      text = title,
-      style = MaterialTheme.typography.labelLarge,
-    )
+    BehaviorMarkdown(markdown = "### $title")
+    HorizontalDivider()
     Text(
       text = "compatibility off",
       style = MaterialTheme.typography.bodySmall,
@@ -201,6 +187,7 @@ private fun TopLevelWidthSection(
       markdown = markdown,
       enableRtlCompatibility = false,
     )
+    HorizontalDivider()
     Text(
       text = "compatibility on",
       style = MaterialTheme.typography.bodySmall,
@@ -249,30 +236,42 @@ private fun ShrinkWrappedBehaviorMarkdown(
 }
 
 private val englishStartingQuoteMarkdown = """
+  ### English-starting quote keeps its gutter on the left
+
   > English opens this quote.
   > אחר כך מופיעה עברית.
 """.trimIndent()
 
 private val hebrewStartingQuoteMarkdown = """
+  ### Hebrew-starting quote keeps its gutter on the right
+
   > הציטוט הזה מתחיל בעברית.
   > English shows up later.
 """.trimIndent()
 
 private val symbolsQuoteMarkdown = """
+  ### Neutral quote falls back to the system side
+
   > () [] {} <> / == -> ++
 """.trimIndent()
 
 private val englishStartingListMarkdown = """
+  ### English first item keeps bullets on the left
+
   - English starts this list item.
   - אחר כך מופיע פריט בעברית.
 """.trimIndent()
 
 private val hebrewStartingListMarkdown = """
+  ### Hebrew first item keeps bullets on the right
+
   - הפריט הראשון מתחיל בעברית.
   - English appears in the second item.
 """.trimIndent()
 
 private val neutralStartingListMarkdown = """
+  ### Neutral first item falls back to the system side
+
   - 12345
   - English appears in the second item.
 """.trimIndent()

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -1,6 +1,5 @@
 package com.halilibo.richtext.markdown
 
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -36,7 +35,6 @@ import com.halilibo.richtext.ui.HorizontalRule
 import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
-import com.halilibo.richtext.ui.string.applyRtlCompatibility
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextDecorations
@@ -320,9 +318,7 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
             richTextRenderOptions,
             richTextDecorations,
             markdownAnimationState,
-            modifier = Modifier
-              .applyRtlCompatibility(richTextRenderOptions)
-              .semantics { heading() },
+            modifier = Modifier.semantics { heading() },
           )
         }
       }

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -1,6 +1,7 @@
 package com.halilibo.richtext.markdown
 
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -257,6 +258,14 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
         BlockQuote(
           markdownAnimationState = markdownAnimationState,
           richTextRenderOptions = richTextRenderOptions,
+          modifier = if (
+            richTextRenderOptions.enableRtlCompatibility &&
+            astNode.links.parent?.type is AstDocument
+          ) {
+            Modifier.fillMaxWidth()
+          } else {
+            Modifier
+          },
           gutterDirection = if (richTextRenderOptions.enableRtlCompatibility) {
             astNode.firstStrongTextDirectionInFirstLine()
           } else {
@@ -279,6 +288,14 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
           listType = Unordered,
           markdownAnimationState = markdownAnimationState,
           richTextRenderOptions = richTextRenderOptions,
+          modifier = if (
+            richTextRenderOptions.enableRtlCompatibility &&
+            astNode.links.parent?.type is AstDocument
+          ) {
+            Modifier.fillMaxWidth()
+          } else {
+            Modifier
+          },
           items = astNode.filterChildrenType<AstListItem>().toList(),
           markerDirection = markerDirection,
         ) { astListItem ->
@@ -303,6 +320,14 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
           listType = Ordered,
           markdownAnimationState = markdownAnimationState,
           richTextRenderOptions = richTextRenderOptions,
+          modifier = if (
+            richTextRenderOptions.enableRtlCompatibility &&
+            astNode.links.parent?.type is AstDocument
+          ) {
+            Modifier.fillMaxWidth()
+          } else {
+            Modifier
+          },
           items = astNode.childrenSequence().toList(),
           startIndex = astNodeType.startNumber - 1,
           markerDirection = markerDirection,

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -1,5 +1,7 @@
 package com.halilibo.richtext.markdown
 
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -28,6 +30,7 @@ import com.halilibo.richtext.markdown.node.AstText
 import com.halilibo.richtext.markdown.node.AstThematicBreak
 import com.halilibo.richtext.markdown.node.AstUnorderedList
 import com.halilibo.richtext.ui.BlockQuote
+import com.halilibo.richtext.ui.BasicRichText
 import com.halilibo.richtext.ui.CodeBlock
 import com.halilibo.richtext.ui.FormattedList
 import com.halilibo.richtext.ui.Heading
@@ -239,7 +242,17 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
     visitChildren: @Composable (AstNode) -> Unit
   ) {
     when (val astNodeType = astNode.type) {
-      is AstDocument -> visitChildren(astNode)
+      is AstDocument -> {
+        BasicRichText(
+          modifier = if (richTextRenderOptions.enableRtlCompatibility) {
+            Modifier.width(IntrinsicSize.Max)
+          } else {
+            Modifier
+          },
+        ) {
+          visitChildren(astNode)
+        }
+      }
       is AstBlockQuote -> {
         BlockQuote(
           markdownAnimationState = markdownAnimationState,

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -78,7 +78,11 @@ internal fun RichTextScope.MarkdownRichText(
     text = richText,
     modifier = if (
       richTextRenderOptions.enableRtlCompatibility &&
-      astNode.links.parent?.type is AstDocument
+      astNode.links.parent?.type.let { parentType ->
+        parentType is AstDocument ||
+          parentType is AstBlockQuote ||
+          parentType is AstListItem
+      }
     ) {
       modifier.fillMaxWidth()
     } else {

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.markdown.node.AstBlockQuote
 import com.halilibo.richtext.markdown.node.AstCode
+import com.halilibo.richtext.markdown.node.AstDocument
 import com.halilibo.richtext.markdown.node.AstEmphasis
 import com.halilibo.richtext.markdown.node.AstFencedCodeBlock
 import com.halilibo.richtext.markdown.node.AstHardLineBreak
@@ -75,7 +76,14 @@ internal fun RichTextScope.MarkdownRichText(
 
   Text(
     text = richText,
-    modifier = modifier,
+    modifier = if (
+      richTextRenderOptions.enableRtlCompatibility &&
+      astNode.links.parent?.type is AstDocument
+    ) {
+      modifier.fillMaxWidth()
+    } else {
+      modifier
+    },
     isLeafText = astNode.isLastInTree(),
     renderOptions = richTextRenderOptions,
     sharedAnimationState = markdownAnimationState,

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -34,7 +34,6 @@ import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.string.RichTextString
 import com.halilibo.richtext.ui.string.Text
-import com.halilibo.richtext.ui.string.applyRtlCompatibility
 import com.halilibo.richtext.ui.string.withFormat
 
 /**
@@ -76,7 +75,7 @@ internal fun RichTextScope.MarkdownRichText(
 
   Text(
     text = richText,
-    modifier = modifier.applyRtlCompatibility(richTextRenderOptions),
+    modifier = modifier,
     isLeafText = astNode.isLastInTree(),
     renderOptions = richTextRenderOptions,
     sharedAnimationState = markdownAnimationState,

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
@@ -120,7 +120,15 @@ public interface BlockQuoteGutter {
     // Measure the contents with the confined width.
     // This must be done before measuring the gutter so that the gutter gets
     // the correct height.
-    val contentsConstraints = constraints.offset(horizontal = -gutterWidth)
+    val contentsConstraints = constraints
+      .offset(horizontal = -gutterWidth)
+      .let {
+        if (richTextRenderOptions.enableRtlCompatibility && it.hasBoundedWidth) {
+          it.copy(minWidth = it.maxWidth)
+        } else {
+          it
+        }
+      }
     val contentsPlaceable = contentsMeasurable.measure(contentsConstraints)
     val layoutWidth = maxOf(contentsPlaceable.width + gutterWidth, constraints.minWidth)
     val layoutHeight = contentsPlaceable.height

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
@@ -77,10 +77,12 @@ public interface BlockQuoteGutter {
 @Composable public fun RichTextScope.BlockQuote(
   markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+  modifier: Modifier = Modifier,
   children: @Composable RichTextScope.() -> Unit
 ): Unit = BlockQuote(
   markdownAnimationState = markdownAnimationState,
   richTextRenderOptions = richTextRenderOptions,
+  modifier = modifier,
   gutterDirection = null,
   children = children,
 )
@@ -91,6 +93,7 @@ public interface BlockQuoteGutter {
 @Composable public fun RichTextScope.BlockQuote(
   markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+  modifier: Modifier = Modifier,
   gutterDirection: TextDirection? = null,
   children: @Composable RichTextScope.() -> Unit
 ) {
@@ -100,7 +103,7 @@ public interface BlockQuoteGutter {
   }
 
   val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
-  Layout(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }, content = {
+  Layout(modifier = modifier.graphicsLayer { this.alpha = alpha.value }, content = {
     with(gutter) { drawGutter() }
     BasicRichText(
       modifier = Modifier.padding(top = spacing, bottom = spacing),

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.BlockQuoteGutter.BarGutter
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
-import com.halilibo.richtext.ui.string.applyRtlCompatibility
 import com.halilibo.richtext.ui.string.resolveRtlCompatibleLayoutDirection
 
 internal val DefaultBlockQuoteGutter = BarGutter()
@@ -101,9 +100,7 @@ public interface BlockQuoteGutter {
   }
 
   val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
-  Layout(modifier = Modifier
-    .applyRtlCompatibility(richTextRenderOptions)
-    .graphicsLayer { this.alpha = alpha.value }, content = {
+  Layout(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }, content = {
     with(gutter) { drawGutter() }
     BasicRichText(
       modifier = Modifier.padding(top = spacing, bottom = spacing),

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -333,7 +333,11 @@ private val LocalListLevel = compositionLocalOf { 0 }
 
     // Then measure the items, offset to the right to allow space for the prefixes and gap.
     val itemConstraints = constraints.copy(
-      maxWidth = (constraints.maxWidth - widestPrefix.width).coerceAtLeast(0)
+      maxWidth = if (constraints.hasBoundedWidth) {
+        (constraints.maxWidth - widestPrefix.width).coerceAtLeast(0)
+      } else {
+        Constraints.Infinity
+      }
     )
     val itemPlaceables = itemMeasurables.map { item ->
       item.measure(itemConstraints)

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -230,6 +230,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
   listType: ListType,
   markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+  modifier: Modifier = Modifier,
   items: List<T>,
   startIndex: Int = 0,
   drawItem: @Composable RichTextScope.(T) -> Unit
@@ -237,6 +238,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
   listType = listType,
   markdownAnimationState = markdownAnimationState,
   richTextRenderOptions = richTextRenderOptions,
+  modifier = modifier,
   items = items,
   startIndex = startIndex,
   markerDirection = null,
@@ -253,6 +255,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
   listType: ListType,
   markdownAnimationState: MarkdownAnimationState = remember { MarkdownAnimationState() },
   richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
+  modifier: Modifier = Modifier,
   items: List<T>,
   startIndex: Int = 0,
   markerDirection: TextDirection? = null,
@@ -267,6 +270,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
 
   PrefixListLayout(
     count = items.size,
+    modifier = modifier,
     itemSpacing = itemSpacing,
     prefixPadding = PaddingValues(start = markerIndent, end = contentsIndent),
     richTextRenderOptions = richTextRenderOptions,
@@ -294,6 +298,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
 
 @Composable private fun PrefixListLayout(
   count: Int,
+  modifier: Modifier,
   itemSpacing: Dp,
   prefixPadding: PaddingValues,
   richTextRenderOptions: RichTextRenderOptions,
@@ -301,7 +306,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
   prefixForIndex: @Composable (index: Int) -> Unit,
   itemForIndex: @Composable (index: Int) -> Unit
 ) {
-  Layout(content = {
+  Layout(modifier = modifier, content = {
     // List markers aren't selectable.
     DisableSelection {
       // Draw the markers first.
@@ -333,6 +338,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
 
     // Then measure the items, offset to the right to allow space for the prefixes and gap.
     val itemConstraints = constraints.copy(
+      minWidth = 0,
       maxWidth = if (constraints.hasBoundedWidth) {
         (constraints.maxWidth - widestPrefix.width).coerceAtLeast(0)
       } else {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RtlCompatibility.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RtlCompatibility.kt
@@ -1,19 +1,10 @@
 package com.halilibo.richtext.ui.string
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.LayoutDirection
 import kotlin.text.CharDirectionality
-
-public fun Modifier.applyRtlCompatibility(renderOptions: RichTextRenderOptions): Modifier =
-  if (renderOptions.enableRtlCompatibility) {
-    fillMaxWidth()
-  } else {
-    this
-  }
 
 internal fun firstStrongTextDirection(text: CharSequence): TextDirection? {
   for (char in text) {


### PR DESCRIPTION
Codex:

Stacks on #63.

## Summary
- decouple `enableRtlCompatibility` from implicit width expansion
- keep top-level markdown paragraphs and headings intrinsically sized unless the caller explicitly provides width
- preserve the existing quote/list/code compatibility behavior while removing the width regression
- add a permanent `zh` Roborazzi preview that proves top-level non-RTL text stays shrink-wrapped with compatibility on

## Testing
- `./gradlew :richtext-ui:allTests :android-sample:recordRoborazziDebug :android-sample:testDebugUnitTest`
