### PR TITLE
Narrow RTL compatibility width behavior

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -77,6 +77,23 @@ private fun CodeWidthBehaviorPreview() {
   }
 }
 
+@Preview(name = "RTL document width behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun DocumentWidthBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      BehaviorSection(
+        title = "English document keeps list aligned to surrounding paragraphs",
+        markdown = englishDocumentWithOrderedListMarkdown,
+      )
+      BehaviorSection(
+        title = "Hebrew document keeps list aligned to surrounding paragraphs",
+        markdown = hebrewDocumentWithOrderedListMarkdown,
+      )
+    }
+  }
+}
+
 @Composable
 private fun BehaviorPreviewSurface(
   content: @Composable () -> Unit,
@@ -208,4 +225,28 @@ private val symbolsCodeMarkdown = """
   ```
   () [] {} <> / == -> ++
   ```
+""".trimIndent()
+
+private val englishDocumentWithOrderedListMarkdown = """
+  The Emoji 15.1 update introduced 118 new emojis, including six completely new concepts:
+
+  1. Phoenix
+  2. Lime
+  3. Brown Mushroom
+  4. Broken Chain
+  5. Head Shaking Horizontally
+
+  For more detailed information on the new emojis and their meanings, you can visit Emojipedia or other emoji-related resources.
+""".trimIndent()
+
+private val hebrewDocumentWithOrderedListMarkdown = """
+  עדכון Emoji 15.1 הציג 118 אימוג׳ים חדשים, כולל שישה רעיונות חדשים לגמרי:
+
+  1. Phoenix
+  2. Lime
+  3. Brown Mushroom
+  4. Broken Chain
+  5. Head Shaking Horizontally
+
+  למידע מפורט יותר על האימוג׳ים החדשים והמשמעויות שלהם אפשר לעיין ב-Emojipedia או במקורות נוספים.
 """.trimIndent()

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -1,12 +1,17 @@
 package com.halilibo.richtext.markdown
 
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.LayoutDirection
 import com.halilibo.richtext.markdown.node.AstBlockNodeType
 import com.halilibo.richtext.markdown.node.AstBlockQuote
 import com.halilibo.richtext.markdown.node.AstDocument
@@ -31,6 +36,7 @@ import com.halilibo.richtext.markdown.node.AstUnorderedList
 import com.halilibo.richtext.ui.BlockQuote
 import com.halilibo.richtext.ui.CodeBlock
 import com.halilibo.richtext.ui.FormattedList
+import com.halilibo.richtext.ui.BasicRichText
 import com.halilibo.richtext.ui.Heading
 import com.halilibo.richtext.ui.HorizontalRule
 import com.halilibo.richtext.ui.ListType.Ordered
@@ -241,7 +247,25 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
     visitChildren: @Composable (AstNode) -> Unit
   ) {
     when (val astNodeType = astNode.type) {
-      is AstDocument -> visitChildren(astNode)
+      is AstDocument -> {
+        if (richTextRenderOptions.enableRtlCompatibility) {
+          val documentDirection = remember(astNode) {
+            astNode.firstStrongTextDirectionInSubtree()
+          }
+          CompositionLocalProvider(
+            LocalLayoutDirection provides resolveDocumentLayoutDirection(
+              documentDirection,
+              LocalLayoutDirection.current,
+            ),
+          ) {
+            BasicRichText(modifier = Modifier.width(IntrinsicSize.Max)) {
+              visitChildren(astNode)
+            }
+          }
+        } else {
+          visitChildren(astNode)
+        }
+      }
       is AstBlockQuote -> {
         BlockQuote(
           markdownAnimationState = markdownAnimationState,
@@ -400,6 +424,15 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       }
     }.let {}
   }
+}
+
+private fun resolveDocumentLayoutDirection(
+  contentDirection: androidx.compose.ui.text.style.TextDirection?,
+  systemDirection: LayoutDirection,
+): LayoutDirection = when (contentDirection) {
+  androidx.compose.ui.text.style.TextDirection.Ltr -> LayoutDirection.Ltr
+  androidx.compose.ui.text.style.TextDirection.Rtl -> LayoutDirection.Rtl
+  else -> systemDirection
 }
 
 /**

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -320,9 +320,7 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
             richTextRenderOptions,
             richTextDecorations,
             markdownAnimationState,
-            modifier = Modifier
-              .applyRtlCompatibility(richTextRenderOptions)
-              .semantics { heading() },
+            modifier = Modifier.semantics { heading() },
           )
         }
       }

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.markdown.node.AstDocument
@@ -75,25 +74,17 @@ internal fun RichTextScope.MarkdownRichText(
   val richText = remember(astNode) {
     computeRichTextString(astNode, inlineContentOverride)
   }
-  val contentDirection = remember(astNode, richTextRenderOptions.enableRtlCompatibility) {
-    if (richTextRenderOptions.enableRtlCompatibility) {
-      astNode.firstStrongTextDirectionInSubtree()
-    } else {
-      null
-    }
-  }
 
   Text(
     text = richText,
     modifier = if (
-      contentDirection == TextDirection.Rtl &&
       astNode.links.parent?.type.let { parentType ->
         parentType is AstDocument ||
           parentType is AstBlockQuote ||
           parentType is AstListItem
       }
     ) {
-      modifier.applyRtlCompatibility(richTextRenderOptions, contentDirection)
+      modifier.applyRtlCompatibility(richTextRenderOptions)
     } else {
       modifier
     },

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -6,8 +6,10 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.halilibo.richtext.markdown.node.AstDocument
 import com.halilibo.richtext.markdown.node.AstBlockQuote
 import com.halilibo.richtext.markdown.node.AstCode
 import com.halilibo.richtext.markdown.node.AstEmphasis
@@ -73,10 +75,28 @@ internal fun RichTextScope.MarkdownRichText(
   val richText = remember(astNode) {
     computeRichTextString(astNode, inlineContentOverride)
   }
+  val contentDirection = remember(astNode, richTextRenderOptions.enableRtlCompatibility) {
+    if (richTextRenderOptions.enableRtlCompatibility) {
+      astNode.firstStrongTextDirectionInSubtree()
+    } else {
+      null
+    }
+  }
 
   Text(
     text = richText,
-    modifier = modifier.applyRtlCompatibility(richTextRenderOptions),
+    modifier = if (
+      contentDirection == TextDirection.Rtl &&
+      astNode.links.parent?.type.let { parentType ->
+        parentType is AstDocument ||
+          parentType is AstBlockQuote ||
+          parentType is AstListItem
+      }
+    ) {
+      modifier.applyRtlCompatibility(richTextRenderOptions, contentDirection)
+    } else {
+      modifier
+    },
     isLeafText = astNode.isLastInTree(),
     renderOptions = richTextRenderOptions,
     sharedAnimationState = markdownAnimationState,

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/TraverseUtils.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/TraverseUtils.kt
@@ -3,6 +3,8 @@ package com.halilibo.richtext.markdown
 import androidx.compose.ui.text.style.TextDirection
 import com.halilibo.richtext.markdown.node.AstCode
 import com.halilibo.richtext.markdown.node.AstHardLineBreak
+import com.halilibo.richtext.markdown.node.AstHtmlBlock
+import com.halilibo.richtext.markdown.node.AstHtmlInline
 import com.halilibo.richtext.markdown.node.AstImage
 import com.halilibo.richtext.markdown.node.AstNode
 import com.halilibo.richtext.markdown.node.AstNodeType
@@ -61,6 +63,8 @@ internal fun AstNode.firstStrongTextDirectionInSubtree(): TextDirection? {
   when (val currentType = type) {
     is AstText -> return firstStrongTextDirection(currentType.literal)
     is AstCode -> return firstStrongTextDirection(currentType.literal)
+    is AstHtmlBlock -> return firstStrongTextDirection(currentType.literal.removeHtmlTags())
+    is AstHtmlInline -> return firstStrongTextDirection(currentType.literal.removeHtmlTags())
     else -> Unit
   }
 
@@ -75,6 +79,8 @@ private fun AstNode.appendFirstLineText(builder: StringBuilder): Boolean {
   when (val currentType = type) {
     is AstText -> builder.append(currentType.literal)
     is AstCode -> builder.append(currentType.literal)
+    is AstHtmlBlock -> builder.append(currentType.literal.removeHtmlTags())
+    is AstHtmlInline -> builder.append(currentType.literal.removeHtmlTags())
     is AstSoftLineBreak, is AstHardLineBreak -> return true
     else -> Unit
   }
@@ -105,4 +111,23 @@ private fun firstStrongTextDirection(text: CharSequence): TextDirection? {
   }
 
   return null
+}
+
+private fun String.removeHtmlTags(): String {
+  if ('<' !in this) {
+    return this
+  }
+
+  val builder = StringBuilder(length)
+  var insideTag = false
+  for (char in this) {
+    when (char) {
+      '<' -> insideTag = true
+      '>' -> insideTag = false
+      else -> if (!insideTag) {
+        builder.append(char)
+      }
+    }
+  }
+  return builder.toString()
 }

--- a/richtext-markdown/src/commonTest/kotlin/com/halilibo/richtext/markdown/TraverseUtilsTest.kt
+++ b/richtext-markdown/src/commonTest/kotlin/com/halilibo/richtext/markdown/TraverseUtilsTest.kt
@@ -1,0 +1,33 @@
+package com.halilibo.richtext.markdown
+
+import androidx.compose.ui.text.style.TextDirection
+import com.halilibo.richtext.markdown.node.AstHtmlBlock
+import com.halilibo.richtext.markdown.node.AstHtmlInline
+import com.halilibo.richtext.markdown.node.AstNode
+import com.halilibo.richtext.markdown.node.AstNodeLinks
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TraverseUtilsTest {
+
+  @Test
+  fun htmlBlockDirectionIgnoresTags() {
+    val astNode = AstNode(
+      type = AstHtmlBlock("<center>שלום עולם</center>"),
+      links = AstNodeLinks(),
+    )
+
+    assertEquals(TextDirection.Rtl, astNode.firstStrongTextDirectionInSubtree())
+  }
+
+  @Test
+  fun htmlInlineDirectionIgnoresTagsForNeutralContent() {
+    val astNode = AstNode(
+      type = AstHtmlInline("<p align=\"right\">12345</p>"),
+      links = AstNodeLinks(),
+    )
+
+    assertNull(astNode.firstStrongTextDirectionInSubtree())
+  }
+}

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BlockQuote.kt
@@ -28,6 +28,7 @@ import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.string.applyRtlCompatibility
 import com.halilibo.richtext.ui.string.resolveRtlCompatibleLayoutDirection
+import com.halilibo.richtext.ui.string.shouldFillWidthForRtlCompatibility
 
 internal val DefaultBlockQuoteGutter = BarGutter()
 
@@ -120,7 +121,15 @@ public interface BlockQuoteGutter {
     // Measure the contents with the confined width.
     // This must be done before measuring the gutter so that the gutter gets
     // the correct height.
-    val contentsConstraints = constraints.offset(horizontal = -gutterWidth)
+    val contentsConstraints = constraints
+      .offset(horizontal = -gutterWidth)
+      .let {
+        if (shouldFillWidthForRtlCompatibility(richTextRenderOptions, gutterDirection) && it.hasBoundedWidth) {
+          it.copy(minWidth = it.maxWidth)
+        } else {
+          it
+        }
+      }
     val contentsPlaceable = contentsMeasurable.measure(contentsConstraints)
     val layoutWidth = maxOf(contentsPlaceable.width + gutterWidth, constraints.minWidth)
     val layoutHeight = contentsPlaceable.height

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -341,9 +341,14 @@ private val LocalListLevel = compositionLocalOf { 0 }
     val widestPrefix = prefixPlaceables.maxByOrNull { it.width }!!
 
     // Then measure the items, offset to the right to allow space for the prefixes and gap.
-    val itemConstraints = constraints.copy(
-      maxWidth = (constraints.maxWidth - widestPrefix.width).coerceAtLeast(0)
-    )
+    val itemConstraints =
+      if (constraints.maxWidth == Constraints.Infinity) {
+        constraints
+      } else {
+        constraints.copy(
+          maxWidth = (constraints.maxWidth - widestPrefix.width).coerceAtLeast(0),
+        )
+      }
     val itemPlaceables = itemMeasurables.map { item ->
       item.measure(itemConstraints)
     }
@@ -351,7 +356,11 @@ private val LocalListLevel = compositionLocalOf { 0 }
     val widestItem = itemPlaceables.maxByOrNull { it.width }!!
 
     val listWidth =
-      if (richTextRenderOptions.enableRtlCompatibility && constraints.hasBoundedWidth) {
+      if (
+        richTextRenderOptions.enableRtlCompatibility &&
+        constraints.hasBoundedWidth &&
+        constraints.maxWidth != Constraints.Infinity
+      ) {
         constraints.maxWidth
       } else {
         widestPrefix.width + widestItem.width

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -275,7 +275,16 @@ private val LocalListLevel = compositionLocalOf { 0 }
       val alpha = rememberMarkdownFade(richTextRenderOptions, markdownAnimationState)
       Box(modifier = Modifier.graphicsLayer { this.alpha = alpha.value }) {
         when (listType) {
-          Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)
+          Ordered -> {
+            val markerTextStyle = if (richTextRenderOptions.enableRtlCompatibility) {
+              currentTextStyle.copy(textDirection = TextDirection.ContentOrLtr)
+            } else {
+              currentTextStyle
+            }
+            CompositionLocalProvider(LocalInternalTextStyle provides markerTextStyle) {
+              listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)
+            }
+          }
           Unordered -> listStyle.unorderedMarkers!!().drawMarker(currentLevel)
         }
       }
@@ -341,7 +350,12 @@ private val LocalListLevel = compositionLocalOf { 0 }
       .toList()
     val widestItem = itemPlaceables.maxByOrNull { it.width }!!
 
-    val listWidth = widestPrefix.width + widestItem.width
+    val listWidth =
+      if (richTextRenderOptions.enableRtlCompatibility && constraints.hasBoundedWidth) {
+        constraints.maxWidth
+      } else {
+        widestPrefix.width + widestItem.width
+      }
     val itemsHeight = itemPlaceables.sumOf { it.height } +
         (itemPlaceables.size - 1) * itemSpacing.roundToPx()
     val prefixesHeight = prefixPlaceables.sumOf { it.height } +

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RtlCompatibility.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RtlCompatibility.kt
@@ -15,6 +15,21 @@ public fun Modifier.applyRtlCompatibility(renderOptions: RichTextRenderOptions):
     this
   }
 
+public fun Modifier.applyRtlCompatibility(
+  renderOptions: RichTextRenderOptions,
+  contentDirection: TextDirection?,
+): Modifier =
+  if (shouldFillWidthForRtlCompatibility(renderOptions, contentDirection)) {
+    fillMaxWidth()
+  } else {
+    this
+  }
+
+internal fun shouldFillWidthForRtlCompatibility(
+  renderOptions: RichTextRenderOptions,
+  contentDirection: TextDirection?,
+): Boolean = renderOptions.enableRtlCompatibility && contentDirection == TextDirection.Rtl
+
 internal fun firstStrongTextDirection(text: CharSequence): TextDirection? {
   for (char in text) {
     when (char.directionality) {

--- a/richtext-ui/src/commonTest/kotlin/com/halilibo/richtext/ui/string/RtlCompatibilityTest.kt
+++ b/richtext-ui/src/commonTest/kotlin/com/halilibo/richtext/ui/string/RtlCompatibilityTest.kt
@@ -3,7 +3,9 @@ package com.halilibo.richtext.ui.string
 import androidx.compose.ui.text.style.TextDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class RtlCompatibilityTest {
 
@@ -20,5 +22,21 @@ class RtlCompatibilityTest {
   @Test
   fun neutralDigitsStayAmbient() {
     assertNull(firstStrongTextDirection("12345"))
+  }
+
+  @Test
+  fun rtlCompatibilityFillWidthOnlyForRtlText() {
+    val renderOptions = RichTextRenderOptions(enableRtlCompatibility = true)
+
+    assertTrue(shouldFillWidthForRtlCompatibility(renderOptions, TextDirection.Rtl))
+    assertFalse(shouldFillWidthForRtlCompatibility(renderOptions, TextDirection.Ltr))
+    assertFalse(shouldFillWidthForRtlCompatibility(renderOptions, null))
+  }
+
+  @Test
+  fun rtlCompatibilityNeverFillsWidthWhenDisabled() {
+    val renderOptions = RichTextRenderOptions(enableRtlCompatibility = false)
+
+    assertFalse(shouldFillWidthForRtlCompatibility(renderOptions, TextDirection.Rtl))
   }
 }


### PR DESCRIPTION
Codex: Narrow the new RTL compatibility width behavior so neutral and LTR markdown stay wrap-content while real RTL blocks still get the placement support from #63.

Testing:
- ./gradlew :richtext-ui:allTests :richtext-markdown:allTests --console=plain
- ./gradlew publishToMavenLocal -PGROUP=com.github.openai.compose-richtext -PVERSION_NAME=b6a8d487b88401f56c3d616d37d08f31da6ee256 --console=plain