### PR TITLE
[codex] Extract RTL compatibility samples

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -1,0 +1,252 @@
+package com.zachklipp.richtext.sample
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.halilibo.richtext.commonmark.Markdown
+import com.halilibo.richtext.ui.material3.RichText
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
+
+@Preview(name = "RTL quote gutter behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun QuoteBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      BehaviorSection(
+        title = "English-starting quote keeps its gutter on the left",
+        markdown = englishStartingQuoteMarkdown,
+      )
+      BehaviorSection(
+        title = "Hebrew-starting quote keeps its gutter on the right",
+        markdown = hebrewStartingQuoteMarkdown,
+      )
+      BehaviorSection(
+        title = "Neutral quote falls back to the system side",
+        markdown = symbolsQuoteMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL list marker behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun ListBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      BehaviorSection(
+        title = "English first item keeps bullets on the left",
+        markdown = englishStartingListMarkdown,
+      )
+      BehaviorSection(
+        title = "Hebrew first item keeps bullets on the right",
+        markdown = hebrewStartingListMarkdown,
+      )
+      BehaviorSection(
+        title = "Neutral first item falls back to the system side",
+        markdown = neutralStartingListMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL code width behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun CodeWidthBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      CodeComparisonSection(
+        title = "English code keeps the same width",
+        markdown = englishCodeMarkdown,
+      )
+      CodeComparisonSection(
+        title = "Symbols-only code keeps the same width",
+        markdown = symbolsCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL document width behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun DocumentWidthBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      BehaviorSection(
+        title = "English document keeps list aligned to surrounding paragraphs",
+        markdown = englishDocumentWithOrderedListMarkdown,
+      )
+      BehaviorSection(
+        title = "Hebrew document keeps list aligned to surrounding paragraphs",
+        markdown = hebrewDocumentWithOrderedListMarkdown,
+      )
+    }
+  }
+}
+
+@Composable
+private fun BehaviorPreviewSurface(
+  content: @Composable () -> Unit,
+) {
+  SampleTheme {
+    Surface {
+      CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        content()
+      }
+    }
+  }
+}
+
+@Composable
+private fun BehaviorPreviewColumn(
+  content: @Composable () -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(24.dp),
+  ) {
+    content()
+  }
+}
+
+@Composable
+private fun BehaviorSection(
+  title: String,
+  markdown: String,
+) {
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.labelLarge,
+    )
+    BehaviorMarkdown(markdown = markdown)
+  }
+}
+
+@Composable
+private fun CodeComparisonSection(
+  title: String,
+  markdown: String,
+) {
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.labelLarge,
+    )
+    Text(
+      text = "compatibility off",
+      style = MaterialTheme.typography.bodySmall,
+    )
+    BehaviorMarkdown(
+      markdown = markdown,
+      enableRtlCompatibility = false,
+    )
+    Text(
+      text = "compatibility on",
+      style = MaterialTheme.typography.bodySmall,
+    )
+    BehaviorMarkdown(
+      markdown = markdown,
+      enableRtlCompatibility = true,
+    )
+  }
+}
+
+@Composable
+private fun BehaviorMarkdown(
+  markdown: String,
+  enableRtlCompatibility: Boolean = true,
+) {
+  RichText(modifier = Modifier.fillMaxWidth()) {
+    Markdown(
+      content = markdown,
+      richtextRenderOptions = RichTextRenderOptions(
+        enableRtlCompatibility = enableRtlCompatibility,
+      ),
+    )
+  }
+}
+
+private val englishStartingQuoteMarkdown = """
+  > English opens this quote.
+  > אחר כך מופיעה עברית.
+""".trimIndent()
+
+private val hebrewStartingQuoteMarkdown = """
+  > הציטוט הזה מתחיל בעברית.
+  > English shows up later.
+""".trimIndent()
+
+private val symbolsQuoteMarkdown = """
+  > () [] {} <> / == -> ++
+""".trimIndent()
+
+private val englishStartingListMarkdown = """
+  - English starts this list item.
+  - אחר כך מופיע פריט בעברית.
+""".trimIndent()
+
+private val hebrewStartingListMarkdown = """
+  - הפריט הראשון מתחיל בעברית.
+  - English appears in the second item.
+""".trimIndent()
+
+private val neutralStartingListMarkdown = """
+  - 12345
+  - English appears in the second item.
+""".trimIndent()
+
+private val englishCodeMarkdown = """
+  ```kotlin
+  val total = value + 42
+  println("A/B -> ${'$'}total")
+  ```
+""".trimIndent()
+
+private val symbolsCodeMarkdown = """
+  ```
+  () [] {} <> / == -> ++
+  ```
+""".trimIndent()
+
+private val englishDocumentWithOrderedListMarkdown = """
+  The Emoji 15.1 update introduced 118 new emojis, including six completely new concepts:
+
+  1. Phoenix
+  2. Lime
+  3. Brown Mushroom
+  4. Broken Chain
+  5. Head Shaking Horizontally
+
+  For more detailed information on the new emojis and their meanings, you can visit Emojipedia or other emoji-related resources.
+""".trimIndent()
+
+private val hebrewDocumentWithOrderedListMarkdown = """
+  עדכון Emoji 15.1 הציג 118 אימוג׳ים חדשים, כולל שישה רעיונות חדשים לגמרי:
+
+  1. Phoenix
+  2. Lime
+  3. Brown Mushroom
+  4. Broken Chain
+  5. Head Shaking Horizontally
+
+  למידע מפורט יותר על האימוג׳ים החדשים והמשמעויות שלהם אפשר לעיין ב-Emojipedia או במקורות נוספים.
+""".trimIndent()

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -65,11 +65,11 @@ private fun ListBehaviorPreview() {
 private fun CodeWidthBehaviorPreview() {
   BehaviorPreviewSurface {
     BehaviorPreviewColumn {
-      CodeComparisonSection(
+      BehaviorSection(
         title = "English code keeps the same width",
         markdown = englishCodeMarkdown,
       )
-      CodeComparisonSection(
+      BehaviorSection(
         title = "Symbols-only code keeps the same width",
         markdown = symbolsCodeMarkdown,
       )
@@ -139,48 +139,13 @@ private fun BehaviorSection(
 }
 
 @Composable
-private fun CodeComparisonSection(
-  title: String,
-  markdown: String,
-) {
-  Column(
-    modifier = Modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
-  ) {
-    Text(
-      text = title,
-      style = MaterialTheme.typography.labelLarge,
-    )
-    Text(
-      text = "compatibility off",
-      style = MaterialTheme.typography.bodySmall,
-    )
-    BehaviorMarkdown(
-      markdown = markdown,
-      enableRtlCompatibility = false,
-    )
-    Text(
-      text = "compatibility on",
-      style = MaterialTheme.typography.bodySmall,
-    )
-    BehaviorMarkdown(
-      markdown = markdown,
-      enableRtlCompatibility = true,
-    )
-  }
-}
-
-@Composable
 private fun BehaviorMarkdown(
   markdown: String,
-  enableRtlCompatibility: Boolean = true,
 ) {
   RichText(modifier = Modifier.fillMaxWidth()) {
     Markdown(
       content = markdown,
-      richtextRenderOptions = RichTextRenderOptions(
-        enableRtlCompatibility = enableRtlCompatibility,
-      ),
+      richtextRenderOptions = RichTextRenderOptions(),
     )
   }
 }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.commonmark.Markdown
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
 import com.halilibo.richtext.ui.material3.RichText
 
 @Preview(name = "English Heading · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
@@ -114,7 +115,12 @@ private fun MarkdownCaseContent(
       )
     }
     RichText(modifier = Modifier.fillMaxWidth()) {
-      Markdown(content = markdown)
+      Markdown(
+        content = markdown,
+        richtextRenderOptions = RichTextRenderOptions(
+          enableRtlCompatibility = true,
+        ),
+      )
     }
   }
 }
@@ -135,6 +141,8 @@ private val englishHeadingMarkdown = """
   This paragraph starts in English, links to [example.com](https://example.com),
   then mentions עברית before ending in English.
 
+  12345
+
   > English quote with a little עברית mixed in.
 """.trimIndent()
 
@@ -143,6 +151,8 @@ private val hebrewHeadingMarkdown = """
 
   הפסקה הזאת מתחילה בעברית, מוסיפה [קישור](https://example.com),
   ואז משלבת English לפני הסיום.
+
+  12345
 
   > ציטוט בעברית עם English בפנים.
 """.trimIndent()

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -117,9 +117,7 @@ private fun MarkdownCaseContent(
     RichText(modifier = Modifier.fillMaxWidth()) {
       Markdown(
         content = markdown,
-        richtextRenderOptions = RichTextRenderOptions(
-          enableRtlCompatibility = true,
-        ),
+        richtextRenderOptions = RichTextRenderOptions(),
       )
     }
   }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
@@ -12,7 +12,6 @@ public data class RichTextRenderOptions(
   val maxPhraseLength: Int = 30,
   val phraseMarkersOverride: List<Char>? = null,
   val onlyRenderVisibleText: Boolean = false,
-  val enableRtlCompatibility: Boolean = false,
   val onTextAnimate: () -> Unit = {},
   val onPhraseAnimate: () -> Unit = {},
 ) {

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextRenderOptions.kt
@@ -12,6 +12,7 @@ public data class RichTextRenderOptions(
   val maxPhraseLength: Int = 30,
   val phraseMarkersOverride: List<Char>? = null,
   val onlyRenderVisibleText: Boolean = false,
+  val enableRtlCompatibility: Boolean = false,
   val onTextAnimate: () -> Unit = {},
   val onPhraseAnimate: () -> Unit = {},
 ) {


### PR DESCRIPTION
Codex:

## Summary
- move the RTL compatibility preview/sample screens into their own branch
- keep the lower PR sample-only and compatible with `main`
- leave the compatibility flag wiring and behavior changes to the stacked RTL implementation PR

## Testing
- `./gradlew :android-sample:testDebugUnitTest`
