### PR TITLE
[codex] Split RTL compatibility samples into stacked PR

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -191,6 +191,58 @@ private fun NeutralItemBehaviorPreview() {
   }
 }
 
+@Preview(name = "RTL multiline paragraph focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun MultilineParagraphFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Later lines do not flip the paragraph direction",
+        markdown = multilineParagraphMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL multiline quote focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun MultilineQuoteFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Later Hebrew quote lines keep the gutter side stable",
+        markdown = multilineQuoteMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL multiline list focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun MultilineListFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Later Hebrew list lines keep the marker side stable",
+        markdown = multilineListMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL multiline code focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun MultilineCodeFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Later Hebrew code lines keep the block side stable",
+        markdown = multilineCodeMarkdown,
+      )
+    }
+  }
+}
+
 @Preview(name = "RTL document width behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
 @Composable
 private fun DocumentWidthBehaviorPreview() {
@@ -261,6 +313,11 @@ private fun ComparisonSection(
   title: String,
   markdown: String,
 ) {
+  val uiDirectionLabel = if (LocalLayoutDirection.current == LayoutDirection.Rtl) {
+    "RTL UI"
+  } else {
+    "LTR UI"
+  }
   Column(
     modifier = Modifier.fillMaxWidth(),
     verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -270,7 +327,7 @@ private fun ComparisonSection(
       style = MaterialTheme.typography.labelLarge,
     )
     Text(
-      text = "compatibility off",
+      text = "compatibility off · $uiDirectionLabel",
       style = MaterialTheme.typography.bodySmall,
     )
     BehaviorCard {
@@ -280,7 +337,7 @@ private fun ComparisonSection(
       )
     }
     Text(
-      text = "compatibility on",
+      text = "compatibility on · $uiDirectionLabel",
       style = MaterialTheme.typography.bodySmall,
     )
     BehaviorCard {
@@ -405,6 +462,30 @@ private val neutralParagraphMarkdown = """
 
 private val singleStrongParagraphMarkdown = """
   word
+""".trimIndent()
+
+private val multilineParagraphMarkdown = """
+  This line starts in English.  
+  עברית בשורה השנייה לא משנה את כיוון הפסקה.
+""".trimIndent()
+
+private val multilineQuoteMarkdown = """
+  > This line starts in English.  
+  > עברית בשורה השנייה משנה רק את הכיוון.
+""".trimIndent()
+
+private val multilineListMarkdown = """
+  - This line starts in English.  
+    עברית בשורה השנייה משנה רק את הכיוון.
+""".trimIndent()
+
+private val multilineCodeMarkdown = """
+  This paragraph is intentionally much wider than the code block below so compatibility mode has room to align the block without changing its side.
+
+  ```
+  This line starts in English.
+  עברית בשורה השנייה משנה רק את הכיוון.
+  ```
 """.trimIndent()
 
 private val englishDocumentWithOrderedListMarkdown = """

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -44,15 +46,15 @@ private fun QuoteBehaviorPreview() {
 private fun ListBehaviorPreview() {
   BehaviorPreviewSurface {
     BehaviorPreviewColumn {
-      BehaviorSection(
+      ComparisonSection(
         title = "English first item keeps bullets on the left",
         markdown = englishStartingListMarkdown,
       )
-      BehaviorSection(
+      ComparisonSection(
         title = "Hebrew first item keeps bullets on the right",
         markdown = hebrewStartingListMarkdown,
       )
-      BehaviorSection(
+      ComparisonSection(
         title = "Neutral first item falls back to the system side",
         markdown = neutralStartingListMarkdown,
       )
@@ -65,13 +67,125 @@ private fun ListBehaviorPreview() {
 private fun CodeWidthBehaviorPreview() {
   BehaviorPreviewSurface {
     BehaviorPreviewColumn {
-      BehaviorSection(
-        title = "English code keeps the same width",
+      ComparisonSection(
+        title = "English code expands to the paragraph width",
         markdown = englishCodeMarkdown,
       )
-      BehaviorSection(
-        title = "Symbols-only code keeps the same width",
+      ComparisonSection(
+        title = "Hebrew code expands and aligns from the right",
+        markdown = hebrewCodeMarkdown,
+      )
+      ComparisonSection(
+        title = "Symbols-only code keeps ambient width",
         markdown = symbolsCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL hebrew code focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun HebrewCodeFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Hebrew code expands and aligns from the right",
+        markdown = hebrewCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "LTR hebrew-only code focused · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Composable
+private fun HebrewOnlyCodeLtrFocusedPreview() {
+  BehaviorPreviewSurface(layoutDirection = LayoutDirection.Ltr) {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Hebrew-only code block in LTR UI",
+        markdown = hebrewOnlyCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL hebrew-only code focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun HebrewOnlyCodeRtlFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Hebrew-only code block in RTL UI",
+        markdown = hebrewOnlyCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL english code width focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun EnglishCodeWidthFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "English code expands to the paragraph width",
+        markdown = englishCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL english code alignment focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun EnglishCodeAlignmentFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "English-first code line stays left-aligned in RTL content",
+        markdown = englishCodeAlignmentMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL symbols code focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun SymbolsCodeFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Symbols-only code keeps ambient width",
+        markdown = symbolsCodeMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL list focused · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun ListFocusedPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Hebrew first item keeps bullets on the right",
+        markdown = hebrewStartingListMarkdown,
+      )
+    }
+  }
+}
+
+@Preview(name = "RTL neutral item behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun NeutralItemBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      ComparisonSection(
+        title = "Small neutral paragraph does not expand",
+        markdown = neutralParagraphMarkdown,
+      )
+      ComparisonSection(
+        title = "Single strong paragraph does not expand by itself",
+        markdown = singleStrongParagraphMarkdown,
       )
     }
   }
@@ -96,11 +210,12 @@ private fun DocumentWidthBehaviorPreview() {
 
 @Composable
 private fun BehaviorPreviewSurface(
+  layoutDirection: LayoutDirection = LayoutDirection.Rtl,
   content: @Composable () -> Unit,
 ) {
   SampleTheme {
     Surface {
-      CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+      CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
         content()
       }
     }
@@ -134,19 +249,80 @@ private fun BehaviorSection(
       text = title,
       style = MaterialTheme.typography.labelLarge,
     )
-    BehaviorMarkdown(markdown = markdown)
+    BehaviorCard {
+      BehaviorMarkdown(markdown = markdown)
+    }
+  }
+}
+
+/** Renders the same markdown with compatibility disabled and enabled for side-by-side review. */
+@Composable
+private fun ComparisonSection(
+  title: String,
+  markdown: String,
+) {
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.labelLarge,
+    )
+    Text(
+      text = "compatibility off",
+      style = MaterialTheme.typography.bodySmall,
+    )
+    BehaviorCard {
+      BehaviorMarkdown(
+        markdown = markdown,
+        enableRtlCompatibility = false,
+      )
+    }
+    Text(
+      text = "compatibility on",
+      style = MaterialTheme.typography.bodySmall,
+    )
+    BehaviorCard {
+      BehaviorMarkdown(
+        markdown = markdown,
+        enableRtlCompatibility = true,
+      )
+    }
+  }
+}
+
+/** Renders one markdown example using the requested RTL compatibility mode. */
+@Composable
+private fun BehaviorMarkdown(
+  markdown: String,
+  enableRtlCompatibility: Boolean = true,
+) {
+  RichText {
+    Markdown(
+      content = markdown,
+      richtextRenderOptions = RichTextRenderOptions(
+        enableRtlCompatibility = enableRtlCompatibility,
+      ),
+    )
   }
 }
 
 @Composable
-private fun BehaviorMarkdown(
-  markdown: String,
+private fun BehaviorCard(
+  content: @Composable () -> Unit,
 ) {
-  RichText(modifier = Modifier.fillMaxWidth()) {
-    Markdown(
-      content = markdown,
-      richtextRenderOptions = RichTextRenderOptions(),
-    )
+  Card(
+    colors = CardDefaults.cardColors(
+      containerColor = MaterialTheme.colorScheme.surfaceVariant,
+    ),
+  ) {
+    Column(
+      modifier = Modifier
+        .padding(16.dp),
+    ) {
+      content()
+    }
   }
 }
 
@@ -180,6 +356,8 @@ private val neutralStartingListMarkdown = """
 """.trimIndent()
 
 private val englishCodeMarkdown = """
+  This paragraph is intentionally much wider than the code block below so compatibility mode has a document width to align against.
+
   ```kotlin
   val total = value + 42
   println("A/B -> ${'$'}total")
@@ -187,9 +365,46 @@ private val englishCodeMarkdown = """
 """.trimIndent()
 
 private val symbolsCodeMarkdown = """
+  This paragraph is intentionally much wider than the symbols-only code block below.
+
   ```
   () [] {} <> / == -> ++
   ```
+""".trimIndent()
+
+private val hebrewCodeMarkdown = """
+  הפסקה הזאת רחבה בכוונה יותר מבלוק הקוד שמתחתיה כדי לוודא שמצב התאימות משתמש ברוחב המסמך.
+
+  ```kotlin
+  val hebrew = "שלום"
+  println(hebrew)
+  ```
+""".trimIndent()
+
+private val hebrewOnlyCodeMarkdown = """
+  הפסקה הזאת רחבה בכוונה יותר מבלוק הקוד שמתחתיה כדי שרוחב המסמך יהיה ברור גם כשכל שורות הקוד בעברית.
+
+  ```
+  שלום
+  להתראות
+  ```
+""".trimIndent()
+
+private val englishCodeAlignmentMarkdown = """
+  הפסקה הזאת רחבה בכוונה יותר מבלוק הקוד שמתחתיה כדי שרוחב המסמך יהיה ברור גם כשהשורה הראשונה באנגלית.
+
+  ```kotlin
+  val x = 1
+  println(x)
+  ```
+""".trimIndent()
+
+private val neutralParagraphMarkdown = """
+  12345
+""".trimIndent()
+
+private val singleStrongParagraphMarkdown = """
+  word
 """.trimIndent()
 
 private val englishDocumentWithOrderedListMarkdown = """

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilitySample.kt
@@ -117,7 +117,9 @@ private fun MarkdownCaseContent(
     RichText(modifier = Modifier.fillMaxWidth()) {
       Markdown(
         content = markdown,
-        richtextRenderOptions = RichTextRenderOptions(),
+        richtextRenderOptions = RichTextRenderOptions(
+          enableRtlCompatibility = true,
+        ),
       )
     }
   }


### PR DESCRIPTION
Codex: This stacks on #63 and moves the Android sample and preview updates into their own review surface.

## What changed
- moves the RTL compatibility sample/demo changes out of the core markdown/rendering PR
- keeps the focused behavior previews and sample wiring in `android-sample`
- leaves `#63` focused on the library behavior, tests, and rendering code only

## Why
The main RTL compatibility PR had both core behavior changes and a large sample/demo diff. Splitting the sample files into a stacked PR makes the review path smaller and keeps the library logic easier to inspect.

## Impact
- no library behavior changes beyond what `#63` already contains
- this PR only changes the Android sample app and previews on top of `codex/rtl-compatibility`

## Testing
- `./gradlew :android-sample:testDebugUnitTest :android-sample:recordRoborazziDebug`
