### PR TITLE
[codex] Fix centered HTML RTL compatibility

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/CenteredHtmlRtlCompatibilityRepro.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/CenteredHtmlRtlCompatibilityRepro.kt
@@ -1,0 +1,69 @@
+package com.zachklipp.richtext.sample
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.halilibo.richtext.commonmark.Markdown
+import com.halilibo.richtext.ui.material3.RichText
+import com.halilibo.richtext.ui.string.RichTextRenderOptions
+
+@Preview(name = "Centered neutral HTML · on · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "Centered neutral HTML · on · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun CenteredNeutralHtmlCompatibilityOnPreview() {
+  CenteredHtmlPreview(
+    markdown = "<center>12345</center>",
+    enableRtlCompatibility = true,
+  )
+}
+
+@Preview(name = "Centered neutral HTML · off · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "Centered neutral HTML · off · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun CenteredNeutralHtmlCompatibilityOffPreview() {
+  CenteredHtmlPreview(
+    markdown = "<center>12345</center>",
+    enableRtlCompatibility = false,
+  )
+}
+
+@Preview(name = "Centered Hebrew HTML · on · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "Centered Hebrew HTML · on · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun CenteredHebrewHtmlCompatibilityOnPreview() {
+  CenteredHtmlPreview(
+    markdown = "<center>שלום עולם</center>",
+    enableRtlCompatibility = true,
+  )
+}
+
+@Preview(name = "Centered Hebrew HTML · off · en-US", locale = "en-rUS", widthDp = 412, showBackground = true)
+@Preview(name = "Centered Hebrew HTML · off · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun CenteredHebrewHtmlCompatibilityOffPreview() {
+  CenteredHtmlPreview(
+    markdown = "<center>שלום עולם</center>",
+    enableRtlCompatibility = false,
+  )
+}
+
+@Composable
+private fun CenteredHtmlPreview(
+  markdown: String,
+  enableRtlCompatibility: Boolean,
+) {
+  SampleTheme {
+    Surface {
+      RichText(modifier = Modifier.fillMaxWidth()) {
+        Markdown(
+          content = markdown,
+          richtextRenderOptions = RichTextRenderOptions(
+            enableRtlCompatibility = enableRtlCompatibility,
+          ),
+        )
+      }
+    }
+  }
+}

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -44,7 +44,6 @@ import com.halilibo.richtext.ui.HorizontalRule
 import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
-import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
@@ -363,11 +362,7 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       }
 
       is AstHtmlBlock -> {
-        Text(text = richTextString {
-          appendInlineContent(content = InlineContent {
-            HtmlBlock(astNodeType.literal)
-          })
-        })
+        HtmlBlock(astNodeType.literal)
       }
 
       is AstLinkReferenceDefinition -> {

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -44,6 +44,7 @@ import com.halilibo.richtext.ui.HorizontalRule
 import com.halilibo.richtext.ui.ListType.Ordered
 import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
+import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextDecorations
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
@@ -362,7 +363,15 @@ private val DefaultAstNodeComposer = object : AstBlockNodeComposer {
       }
 
       is AstHtmlBlock -> {
-        HtmlBlock(astNodeType.literal)
+        if (richTextRenderOptions.enableRtlCompatibility) {
+          HtmlBlock(astNodeType.literal)
+        } else {
+          Text(text = richTextString {
+            appendInlineContent(content = InlineContent {
+              HtmlBlock(astNodeType.literal)
+            })
+          })
+        }
       }
 
       is AstLinkReferenceDefinition -> {


### PR DESCRIPTION
Codex: Fix centered HTML rendering in RTL compatibility mode.

## What changed
- render `AstHtmlBlock` directly as block content instead of wrapping it in inline placeholder content
- add Roborazzi preview repro coverage for centered neutral and Hebrew HTML with RTL compatibility both on and off

## Why
- the document-level intrinsic-width wrapper used by RTL compatibility interacted badly with inline HTML block placeholders
- centered HTML then collapsed into a vertical stack instead of staying horizontally laid out

## Impact
- centered HTML remains readable and horizontal when `enableRtlCompatibility = true`
- the existing RTL document-width behavior stays covered by the preview suite

## Testing
- `./gradlew :android-sample:testDebugUnitTest --console=plain`
- `./gradlew :android-sample:recordRoborazziDebug --console=plain`
- `./gradlew :richtext-markdown:allTests --console=plain`
- `./gradlew :android-sample:testDebugUnitTest :richtext-markdown:allTests --console=plain`
