### PR TITLE
[codex] Avoid intrinsic sizing for RTL markdown documents

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -94,6 +94,20 @@ private fun DocumentWidthBehaviorPreview() {
   }
 }
 
+@Preview(name = "RTL compatibility table · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun TableCompatibilityPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      BehaviorSection(
+        title = "Markdown table renders with RTL compatibility enabled",
+        markdown = tableMarkdown,
+        richTextRenderOptions = RichTextRenderOptions(enableRtlCompatibility = true),
+      )
+    }
+  }
+}
+
 @Composable
 private fun BehaviorPreviewSurface(
   content: @Composable () -> Unit,
@@ -125,6 +139,7 @@ private fun BehaviorPreviewColumn(
 private fun BehaviorSection(
   title: String,
   markdown: String,
+  richTextRenderOptions: RichTextRenderOptions = RichTextRenderOptions(),
 ) {
   Column(
     modifier = Modifier.fillMaxWidth(),
@@ -134,18 +149,22 @@ private fun BehaviorSection(
       text = title,
       style = MaterialTheme.typography.labelLarge,
     )
-    BehaviorMarkdown(markdown = markdown)
+    BehaviorMarkdown(
+      markdown = markdown,
+      richTextRenderOptions = richTextRenderOptions,
+    )
   }
 }
 
 @Composable
 private fun BehaviorMarkdown(
   markdown: String,
+  richTextRenderOptions: RichTextRenderOptions,
 ) {
   RichText(modifier = Modifier.fillMaxWidth()) {
     Markdown(
       content = markdown,
-      richtextRenderOptions = RichTextRenderOptions(),
+      richtextRenderOptions = richTextRenderOptions,
     )
   }
 }
@@ -214,4 +233,15 @@ private val hebrewDocumentWithOrderedListMarkdown = """
   5. Head Shaking Horizontally
 
   למידע מפורט יותר על האימוג׳ים החדשים והמשמעויות שלהם אפשר לעיין ב-Emojipedia או במקורות נוספים.
+""".trimIndent()
+
+private val tableMarkdown = """
+  פסקה בעברית לפני הטבלה.
+
+  | כותרת | Status |
+  | --- | --- |
+  | שלום | Ready |
+  | עברית ואז English | Works |
+
+  English paragraph after the table.
 """.trimIndent()

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMarkdown.kt
@@ -1,13 +1,12 @@
 package com.halilibo.richtext.markdown
 
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import com.halilibo.richtext.markdown.rtl.LocalCompatibilityTextAlignOverride
@@ -95,19 +94,8 @@ public fun RichTextScope.BasicMarkdown(
 ) {
   val markdownAnimationState = remember { MarkdownAnimationState() }
 
-  if (richTextRenderOptions.enableRtlCompatibility && astNode.type is AstDocument) {
-    BasicRichText(modifier = Modifier.width(IntrinsicSize.Max)) {
-      RecursiveRenderMarkdownAst(
-        astNode = astNode,
-        contentOverride = contentOverride,
-        inlineContentOverride = inlineContentOverride,
-        richTextRenderOptions = richTextRenderOptions,
-        richTextDecorations = richTextDecorations,
-        markdownAnimationState = markdownAnimationState,
-        astNodeComposer = astBlockNodeComposer,
-      )
-    }
-  } else {
+  @Composable
+  fun RenderMarkdown(richTextRenderOptions: RichTextRenderOptions) {
     RecursiveRenderMarkdownAst(
       astNode = astNode,
       contentOverride = contentOverride,
@@ -118,6 +106,65 @@ public fun RichTextScope.BasicMarkdown(
       astNodeComposer = astBlockNodeComposer,
     )
   }
+
+  if (richTextRenderOptions.enableRtlCompatibility && astNode.type is AstDocument) {
+    val measureRenderOptions = remember(richTextRenderOptions) {
+      richTextRenderOptions.copy(
+        animate = false,
+        enableRtlCompatibility = false,
+      )
+    }
+    RtlCompatibilityDocument(
+      measureContent = {
+        BasicRichText {
+          RenderMarkdown(richTextRenderOptions = measureRenderOptions)
+        }
+      },
+      content = {
+        BasicRichText {
+          RenderMarkdown(richTextRenderOptions = richTextRenderOptions)
+        }
+      },
+    )
+  } else {
+    RenderMarkdown(richTextRenderOptions = richTextRenderOptions)
+  }
+}
+
+@Composable
+private fun RtlCompatibilityDocument(
+  measureContent: @Composable () -> Unit,
+  content: @Composable () -> Unit,
+) {
+  SubcomposeLayout { constraints ->
+    val measureConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+    val measuredWidth = subcompose(RtlCompatibilityDocumentSlot.Measure, measureContent)
+      .map { it.measure(measureConstraints) }
+      .maxOfOrNull { it.width }
+      ?.coerceIn(constraints.minWidth, constraints.maxWidth)
+      ?: constraints.minWidth
+
+    val contentPlaceables = subcompose(RtlCompatibilityDocumentSlot.Content, content)
+      .map {
+        it.measure(
+          constraints.copy(
+            minWidth = measuredWidth,
+            maxWidth = measuredWidth,
+            minHeight = 0,
+          )
+        )
+      }
+    val height = (contentPlaceables.maxOfOrNull { it.height } ?: 0)
+      .coerceIn(constraints.minHeight, constraints.maxHeight)
+    layout(measuredWidth, height) {
+      contentPlaceables.forEach { it.placeRelative(0, 0) }
+    }
+  }
+}
+
+private enum class RtlCompatibilityDocumentSlot {
+  Measure,
+  Content,
 }
 
 /**


### PR DESCRIPTION
Codex:

## Summary
- Replaced the RTL markdown document IntrinsicSize.Max wrapper with an internal measurement pass that uses real child measurement instead of intrinsic measurement.
- Added a generated Roborazzi preview case for a markdown table rendered with RTL compatibility enabled.
- Passed render options through the RTL behavior preview helper so the table regression path stays explicit.

## Root cause
- The RTL document wrapper asked the whole markdown tree for intrinsic width. Markdown tables render through SubcomposeLayout, which cannot answer intrinsic measurement, and future subcomposed block nodes would have the same problem.

## Testing
- ./gradlew :android-sample:recordRoborazziDebug :android-sample:testDebugUnitTest
- ./gradlew :android-sample:testDebugUnitTest :richtext-markdown:allTests
- ./gradlew check