### PR TITLE
[codex] Add markdown table behavior preview

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RtlCompatibilityBehaviorSample.kt
@@ -94,6 +94,19 @@ private fun DocumentWidthBehaviorPreview() {
   }
 }
 
+@Preview(name = "RTL table behavior · he-IL", locale = "he-rIL", widthDp = 412, showBackground = true)
+@Composable
+private fun TableBehaviorPreview() {
+  BehaviorPreviewSurface {
+    BehaviorPreviewColumn {
+      BehaviorSection(
+        title = "Markdown table renders in RTL layout",
+        markdown = tableMarkdown,
+      )
+    }
+  }
+}
+
 @Composable
 private fun BehaviorPreviewSurface(
   content: @Composable () -> Unit,
@@ -214,4 +227,15 @@ private val hebrewDocumentWithOrderedListMarkdown = """
   5. Head Shaking Horizontally
 
   למידע מפורט יותר על האימוג׳ים החדשים והמשמעויות שלהם אפשר לעיין ב-Emojipedia או במקורות נוספים.
+""".trimIndent()
+
+private val tableMarkdown = """
+  פסקה בעברית לפני הטבלה.
+
+  | כותרת | Status |
+  | --- | --- |
+  | שלום | Ready |
+  | עברית ואז English | Works |
+
+  English paragraph after the table.
 """.trimIndent()


### PR DESCRIPTION
Codex:

Summary:
- Adds a generated Roborazzi preview that renders a mixed Hebrew/English markdown table in the RTL behavior sample.
- Keeps this branch scoped to the table render sample; the RTL compatibility sizing implementation is in the stacked follow-up.

Testing:
- ./gradlew :android-sample:recordRoborazziDebug :android-sample:testDebugUnitTest