### PR TITLE
[codex] Apply bidi direction per code line

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
@@ -8,6 +8,9 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -17,7 +20,10 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.rtl.fillMaxWidthForRtlCompatibility
+import com.halilibo.richtext.ui.rtl.firstStrongTextDirection
 import com.halilibo.richtext.ui.rtl.toCompatibilityDirection
+import com.halilibo.richtext.ui.rtl.toCompatibilityTextAlign
+import com.halilibo.richtext.ui.rtl.toCompatibilityTextDirection
 import com.halilibo.richtext.ui.string.MarkdownAnimationState
 import com.halilibo.richtext.ui.string.RichTextRenderOptions
 
@@ -82,15 +88,31 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
     textAlign = textAlign,
     textDirection = textDirection,
   ) {
-    Text(
-      text = text,
-      modifier = Modifier.fillMaxWidthForRtlCompatibility(
-        enableRtlCompatibility = richTextRenderOptions.enableRtlCompatibility,
-        contentDirection = compatibilityDirection,
-      ),
-      textAlign = textAlign,
-      textDirection = textDirection,
+    val textModifier = Modifier.fillMaxWidthForRtlCompatibility(
+      enableRtlCompatibility = richTextRenderOptions.enableRtlCompatibility,
+      contentDirection = compatibilityDirection,
     )
+
+    if (richTextRenderOptions.enableRtlCompatibility) {
+      val codeBlockText = remember(text, textAlign, textDirection) {
+        text.applyLineDirectionForCodeBlock(
+          fallbackTextAlign = textAlign,
+          fallbackTextDirection = textDirection,
+        )
+      }
+
+      Text(
+        text = codeBlockText,
+        modifier = textModifier,
+      )
+    } else {
+      Text(
+        text = text,
+        modifier = textModifier,
+        textAlign = textAlign,
+        textDirection = textDirection,
+      )
+    }
   }
 }
 
@@ -149,3 +171,63 @@ internal expect fun RichTextScope.CodeBlockLayout(
   wordWrap: Boolean,
   children: @Composable RichTextScope.(Modifier) -> Unit
 )
+
+internal fun String.applyLineDirectionForCodeBlock(
+  fallbackTextAlign: TextAlign?,
+  fallbackTextDirection: TextDirection?,
+): AnnotatedString {
+  val fallbackParagraphStyle = ParagraphStyle(
+    textAlign = fallbackTextAlign ?: TextAlign.Unspecified,
+    textDirection = fallbackTextDirection ?: TextDirection.Unspecified,
+  ).takeIf {
+    fallbackTextAlign != null || fallbackTextDirection != null
+  }
+
+  return buildAnnotatedString {
+    append(this@applyLineDirectionForCodeBlock)
+
+    var lineStart = 0
+    while (lineStart < length) {
+      val lineBreakIndex = indexOfLineBreak(startIndex = lineStart)
+      val lineEnd = lineBreakIndex.takeIf { it >= 0 } ?: length
+      val nextLineStart = when {
+        lineBreakIndex < 0 -> length
+        this@applyLineDirectionForCodeBlock[lineBreakIndex] == '\r' &&
+          lineBreakIndex + 1 < length &&
+          this@applyLineDirectionForCodeBlock[lineBreakIndex + 1] == '\n' -> lineBreakIndex + 2
+        else -> lineBreakIndex + 1
+      }
+
+      val paragraphStyle = this@applyLineDirectionForCodeBlock
+        .subSequence(lineStart, lineEnd)
+        .firstStrongTextDirection()
+        ?.let { direction ->
+          ParagraphStyle(
+            textAlign = direction.toCompatibilityTextAlign() ?: TextAlign.Unspecified,
+            textDirection = direction.toCompatibilityTextDirection() ?: TextDirection.Unspecified,
+          )
+        }
+        ?: fallbackParagraphStyle
+
+      if (paragraphStyle != null) {
+        addStyle(
+          paragraphStyle,
+          start = lineStart,
+          end = nextLineStart,
+        )
+      }
+
+      lineStart = nextLineStart
+    }
+  }
+}
+
+private fun CharSequence.indexOfLineBreak(startIndex: Int): Int {
+  for (index in startIndex until length) {
+    if (this[index] == '\n' || this[index] == '\r') {
+      return index
+    }
+  }
+
+  return -1
+}

--- a/richtext-ui/src/commonTest/kotlin/com/halilibo/richtext/ui/CodeBlockTest.kt
+++ b/richtext-ui/src/commonTest/kotlin/com/halilibo/richtext/ui/CodeBlockTest.kt
@@ -1,0 +1,84 @@
+package com.halilibo.richtext.ui
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CodeBlockTest {
+
+  @Test
+  fun compatibilityAppliesParagraphDirectionPerLine() {
+    val text = "שלום\nhello"
+
+    val paragraphStyles = text.applyLineDirectionForCodeBlock(
+      fallbackTextAlign = TextAlign.Right,
+      fallbackTextDirection = TextDirection.ContentOrRtl,
+    ).paragraphStyles
+
+    assertEquals(
+      listOf(
+        AnnotatedParagraphStyle(
+          start = 0,
+          end = 5,
+          textAlign = TextAlign.Right,
+          textDirection = TextDirection.ContentOrRtl,
+        ),
+        AnnotatedParagraphStyle(
+          start = 5,
+          end = text.length,
+          textAlign = TextAlign.Left,
+          textDirection = TextDirection.ContentOrLtr,
+        ),
+      ),
+      paragraphStyles.toParagraphStyles(),
+    )
+  }
+
+  @Test
+  fun neutralLineFallsBackToBlockDirection() {
+    val text = "123\nשלום"
+
+    val paragraphStyles = text.applyLineDirectionForCodeBlock(
+      fallbackTextAlign = TextAlign.Left,
+      fallbackTextDirection = TextDirection.ContentOrLtr,
+    ).paragraphStyles
+
+    assertEquals(
+      listOf(
+        AnnotatedParagraphStyle(
+          start = 0,
+          end = 4,
+          textAlign = TextAlign.Left,
+          textDirection = TextDirection.ContentOrLtr,
+        ),
+        AnnotatedParagraphStyle(
+          start = 4,
+          end = text.length,
+          textAlign = TextAlign.Right,
+          textDirection = TextDirection.ContentOrRtl,
+        ),
+      ),
+      paragraphStyles.toParagraphStyles(),
+    )
+  }
+}
+
+private data class AnnotatedParagraphStyle(
+  val start: Int,
+  val end: Int,
+  val textAlign: TextAlign,
+  val textDirection: TextDirection,
+)
+
+private fun List<AnnotatedString.Range<ParagraphStyle>>.toParagraphStyles(): List<AnnotatedParagraphStyle> =
+  map { range ->
+    AnnotatedParagraphStyle(
+      start = range.start,
+      end = range.end,
+      textAlign = range.item.textAlign,
+      textDirection = range.item.textDirection,
+    )
+  }


### PR DESCRIPTION
Codex: This changes code blocks in RTL compatibility mode to choose paragraph direction per rendered line, using the shared first-strong-character rule. English code stays left-aligned, Hebrew and Arabic code stay right-aligned, and mixed blocks stop collapsing to a single block-wide direction.

## Testing
- > Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:generateExternalPluginSpecBuilders UP-TO-DATE
> Task :buildSrc:extractPrecompiledScriptPluginPlugins UP-TO-DATE
> Task :buildSrc:compilePluginsBlocks UP-TO-DATE
> Task :buildSrc:generatePrecompiledScriptPluginAccessors UP-TO-DATE
> Task :buildSrc:generateScriptPluginAdapters UP-TO-DATE
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Configure project :
warning: Dokka Gradle plugin V1 is deprecated
    
    Dokka Gradle plugin V1 is deprecated, and will be removed in Dokka version 2.1.0
    Please migrate to Dokka Gradle plugin V2. This will require updating your project.
    To learn about migrating read the migration guide https://kotl.in/dokka-gradle-migration
    
    To start migrating to Dokka Gradle plugin V2 add
        org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
    into your project's `gradle.properties` file.
    
    We would appreciate your feedback!
     - Please report any feedback or problems https://kotl.in/dokka-issues
     - Chat with the community visit #dokka in https://kotlinlang.slack.com/ (To sign up visit https://kotl.in/slack)
    

> Task :richtext-ui:kmpPartiallyResolvedDependenciesChecker
> Task :richtext-ui:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForCommonMain SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForJvmMain SKIPPED
> Task :richtext-ui:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :richtext-ui:generateComposeResClass SKIPPED
> Task :richtext-ui:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :richtext-ui:compileKotlinJvm UP-TO-DATE
> Task :richtext-ui:compileJvmMainJava NO-SOURCE
> Task :richtext-ui:convertXmlValueResourcesForCommonTest NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForCommonTest NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForCommonTest NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForCommonTest SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForJvmTest NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForJvmTest NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForJvmTest NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForJvmTest SKIPPED
> Task :richtext-ui:assembleJvmMainResources UP-TO-DATE
> Task :richtext-ui:jvmProcessResources UP-TO-DATE
> Task :richtext-ui:processJvmMainResources SKIPPED
> Task :richtext-ui:jvmMainClasses UP-TO-DATE
> Task :richtext-ui:jvmJar UP-TO-DATE
> Task :richtext-ui:compileTestKotlinJvm UP-TO-DATE
> Task :richtext-ui:compileJvmTestJava NO-SOURCE
> Task :richtext-ui:assembleJvmTestResources UP-TO-DATE
> Task :richtext-ui:jvmTestProcessResources UP-TO-DATE
> Task :richtext-ui:processJvmTestResources SKIPPED
> Task :richtext-ui:jvmTestClasses UP-TO-DATE
> Task :richtext-ui:jvmTest UP-TO-DATE
> Task :richtext-ui:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidMain SKIPPED
> Task :richtext-ui:generateActualResourceCollectorsForAndroidMain SKIPPED
> Task :richtext-ui:preBuild UP-TO-DATE
> Task :richtext-ui:preDebugBuild UP-TO-DATE
> Task :richtext-ui:generateDebugResValues UP-TO-DATE
> Task :richtext-ui:generateDebugResources UP-TO-DATE
> Task :richtext-ui:packageDebugResources UP-TO-DATE
> Task :richtext-ui:processDebugNavigationResources UP-TO-DATE
> Task :richtext-ui:parseDebugLocalResources UP-TO-DATE
> Task :richtext-ui:generateDebugRFile UP-TO-DATE
> Task :richtext-ui:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidDebug SKIPPED
> Task :richtext-ui:compileDebugKotlinAndroid UP-TO-DATE
> Task :richtext-ui:javaPreCompileDebug UP-TO-DATE
> Task :richtext-ui:compileDebugJavaWithJavac NO-SOURCE
> Task :richtext-ui:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :richtext-ui:bundleLibCompileToJarDebug UP-TO-DATE
> Task :richtext-ui:preDebugUnitTestBuild UP-TO-DATE
> Task :richtext-ui:generateDebugUnitTestStubRFile UP-TO-DATE
> Task :richtext-ui:convertXmlValueResourcesForAndroidUnitTest NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidUnitTest NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidUnitTest NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidUnitTest SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForAndroidUnitTestDebug NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidUnitTestDebug NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidUnitTestDebug NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidUnitTestDebug SKIPPED
> Task :richtext-ui:compileDebugUnitTestKotlinAndroid UP-TO-DATE
> Task :richtext-ui:javaPreCompileDebugUnitTest UP-TO-DATE
> Task :richtext-ui:compileDebugUnitTestJavaWithJavac NO-SOURCE
> Task :richtext-ui:processDebugJavaRes UP-TO-DATE
> Task :richtext-ui:processDebugUnitTestJavaRes UP-TO-DATE
> Task :richtext-ui:testDebugUnitTest UP-TO-DATE
> Task :richtext-ui:preReleaseBuild UP-TO-DATE
> Task :richtext-ui:generateReleaseResValues UP-TO-DATE
> Task :richtext-ui:generateReleaseResources UP-TO-DATE
> Task :richtext-ui:packageReleaseResources UP-TO-DATE
> Task :richtext-ui:processReleaseNavigationResources UP-TO-DATE
> Task :richtext-ui:parseReleaseLocalResources UP-TO-DATE
> Task :richtext-ui:generateReleaseRFile UP-TO-DATE
> Task :richtext-ui:convertXmlValueResourcesForAndroidRelease NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidRelease NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidRelease NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidRelease SKIPPED
> Task :richtext-ui:compileReleaseKotlinAndroid UP-TO-DATE
> Task :richtext-ui:javaPreCompileRelease UP-TO-DATE
> Task :richtext-ui:compileReleaseJavaWithJavac NO-SOURCE
> Task :richtext-ui:bundleLibRuntimeToJarRelease UP-TO-DATE
> Task :richtext-ui:bundleLibCompileToJarRelease UP-TO-DATE
> Task :richtext-ui:preReleaseUnitTestBuild UP-TO-DATE
> Task :richtext-ui:generateReleaseUnitTestStubRFile UP-TO-DATE
> Task :richtext-ui:convertXmlValueResourcesForAndroidUnitTestRelease NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidUnitTestRelease NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidUnitTestRelease NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidUnitTestRelease SKIPPED
> Task :richtext-ui:compileReleaseUnitTestKotlinAndroid UP-TO-DATE
> Task :richtext-ui:javaPreCompileReleaseUnitTest UP-TO-DATE
> Task :richtext-ui:compileReleaseUnitTestJavaWithJavac NO-SOURCE
> Task :richtext-ui:processReleaseJavaRes UP-TO-DATE
> Task :richtext-ui:processReleaseUnitTestJavaRes UP-TO-DATE
> Task :richtext-ui:testReleaseUnitTest UP-TO-DATE
> Task :richtext-ui:allTests UP-TO-DATE
> Task :richtext-markdown:kmpPartiallyResolvedDependenciesChecker
> Task :richtext-markdown:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForCommonMain SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForJvmMain SKIPPED
> Task :richtext-markdown:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :richtext-markdown:generateComposeResClass SKIPPED
> Task :richtext-markdown:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :richtext-markdown:compileKotlinJvm UP-TO-DATE
> Task :richtext-markdown:compileJvmMainJava NO-SOURCE
> Task :richtext-markdown:convertXmlValueResourcesForCommonTest NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForCommonTest NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForCommonTest NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForCommonTest SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForJvmTest NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForJvmTest NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForJvmTest NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForJvmTest SKIPPED
> Task :richtext-markdown:assembleJvmMainResources UP-TO-DATE
> Task :richtext-markdown:jvmProcessResources UP-TO-DATE
> Task :richtext-markdown:processJvmMainResources SKIPPED
> Task :richtext-markdown:jvmMainClasses UP-TO-DATE
> Task :richtext-markdown:jvmJar UP-TO-DATE
> Task :richtext-markdown:compileTestKotlinJvm UP-TO-DATE
> Task :richtext-markdown:compileJvmTestJava NO-SOURCE
> Task :richtext-markdown:assembleJvmTestResources UP-TO-DATE
> Task :richtext-markdown:jvmTestProcessResources UP-TO-DATE
> Task :richtext-markdown:processJvmTestResources SKIPPED
> Task :richtext-markdown:jvmTestClasses UP-TO-DATE
> Task :richtext-markdown:jvmTest UP-TO-DATE
> Task :richtext-markdown:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidMain SKIPPED
> Task :richtext-markdown:generateActualResourceCollectorsForAndroidMain SKIPPED
> Task :richtext-markdown:preBuild UP-TO-DATE
> Task :richtext-markdown:preDebugBuild UP-TO-DATE
> Task :richtext-markdown:generateDebugResValues UP-TO-DATE
> Task :richtext-markdown:generateDebugResources UP-TO-DATE
> Task :richtext-markdown:packageDebugResources UP-TO-DATE
> Task :richtext-markdown:processDebugNavigationResources UP-TO-DATE
> Task :richtext-markdown:parseDebugLocalResources UP-TO-DATE
> Task :richtext-markdown:generateDebugRFile UP-TO-DATE
> Task :richtext-markdown:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidDebug SKIPPED
> Task :richtext-markdown:compileDebugKotlinAndroid UP-TO-DATE
> Task :richtext-markdown:javaPreCompileDebug UP-TO-DATE
> Task :richtext-markdown:compileDebugJavaWithJavac NO-SOURCE
> Task :richtext-markdown:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :richtext-markdown:bundleLibCompileToJarDebug UP-TO-DATE
> Task :richtext-markdown:preDebugUnitTestBuild UP-TO-DATE
> Task :richtext-markdown:generateDebugUnitTestStubRFile UP-TO-DATE
> Task :richtext-markdown:convertXmlValueResourcesForAndroidUnitTest NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidUnitTest NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidUnitTest NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidUnitTest SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForAndroidUnitTestDebug NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidUnitTestDebug NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidUnitTestDebug NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidUnitTestDebug SKIPPED
> Task :richtext-markdown:compileDebugUnitTestKotlinAndroid UP-TO-DATE
> Task :richtext-markdown:javaPreCompileDebugUnitTest UP-TO-DATE
> Task :richtext-markdown:compileDebugUnitTestJavaWithJavac NO-SOURCE
> Task :richtext-markdown:processDebugJavaRes UP-TO-DATE
> Task :richtext-markdown:processDebugUnitTestJavaRes UP-TO-DATE
> Task :richtext-markdown:testDebugUnitTest UP-TO-DATE
> Task :richtext-markdown:preReleaseBuild UP-TO-DATE
> Task :richtext-markdown:generateReleaseResValues UP-TO-DATE
> Task :richtext-markdown:generateReleaseResources UP-TO-DATE
> Task :richtext-markdown:packageReleaseResources UP-TO-DATE
> Task :richtext-markdown:processReleaseNavigationResources UP-TO-DATE
> Task :richtext-markdown:parseReleaseLocalResources UP-TO-DATE
> Task :richtext-markdown:generateReleaseRFile UP-TO-DATE
> Task :richtext-markdown:convertXmlValueResourcesForAndroidRelease NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidRelease NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidRelease NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidRelease SKIPPED
> Task :richtext-markdown:compileReleaseKotlinAndroid UP-TO-DATE
> Task :richtext-markdown:javaPreCompileRelease UP-TO-DATE
> Task :richtext-markdown:compileReleaseJavaWithJavac NO-SOURCE
> Task :richtext-markdown:bundleLibRuntimeToJarRelease UP-TO-DATE
> Task :richtext-markdown:bundleLibCompileToJarRelease UP-TO-DATE
> Task :richtext-markdown:preReleaseUnitTestBuild UP-TO-DATE
> Task :richtext-markdown:generateReleaseUnitTestStubRFile UP-TO-DATE
> Task :richtext-markdown:convertXmlValueResourcesForAndroidUnitTestRelease NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidUnitTestRelease NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidUnitTestRelease NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidUnitTestRelease SKIPPED
> Task :richtext-markdown:compileReleaseUnitTestKotlinAndroid UP-TO-DATE
> Task :richtext-markdown:javaPreCompileReleaseUnitTest UP-TO-DATE
> Task :richtext-markdown:compileReleaseUnitTestJavaWithJavac NO-SOURCE
> Task :richtext-markdown:processReleaseJavaRes UP-TO-DATE
> Task :richtext-markdown:processReleaseUnitTestJavaRes UP-TO-DATE
> Task :richtext-markdown:testReleaseUnitTest UP-TO-DATE
> Task :richtext-markdown:allTests UP-TO-DATE

BUILD SUCCESSFUL in 1s
93 actionable tasks: 2 executed, 91 up-to-date
- > Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:generateExternalPluginSpecBuilders UP-TO-DATE
> Task :buildSrc:extractPrecompiledScriptPluginPlugins UP-TO-DATE
> Task :buildSrc:compilePluginsBlocks UP-TO-DATE
> Task :buildSrc:generatePrecompiledScriptPluginAccessors UP-TO-DATE
> Task :buildSrc:generateScriptPluginAdapters UP-TO-DATE
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Configure project :
warning: Dokka Gradle plugin V1 is deprecated
    
    Dokka Gradle plugin V1 is deprecated, and will be removed in Dokka version 2.1.0
    Please migrate to Dokka Gradle plugin V2. This will require updating your project.
    To learn about migrating read the migration guide https://kotl.in/dokka-gradle-migration
    
    To start migrating to Dokka Gradle plugin V2 add
        org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
    into your project's `gradle.properties` file.
    
    We would appreciate your feedback!
     - Please report any feedback or problems https://kotl.in/dokka-issues
     - Chat with the community visit #dokka in https://kotlinlang.slack.com/ (To sign up visit https://kotl.in/slack)
    

> Task :android-sample:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :android-sample:preBuild UP-TO-DATE
> Task :android-sample:preDebugBuild UP-TO-DATE
> Task :richtext-commonmark:preBuild UP-TO-DATE
> Task :richtext-commonmark:preDebugBuild UP-TO-DATE
> Task :richtext-commonmark:writeDebugAarMetadata UP-TO-DATE
> Task :richtext-markdown:preBuild UP-TO-DATE
> Task :richtext-markdown:preDebugBuild UP-TO-DATE
> Task :richtext-markdown:writeDebugAarMetadata UP-TO-DATE
> Task :richtext-ui:preBuild UP-TO-DATE
> Task :richtext-ui:preDebugBuild UP-TO-DATE
> Task :richtext-ui:writeDebugAarMetadata UP-TO-DATE
> Task :richtext-ui-material3:preBuild UP-TO-DATE
> Task :richtext-ui-material3:preDebugBuild UP-TO-DATE
> Task :richtext-ui-material3:writeDebugAarMetadata UP-TO-DATE
> Task :android-sample:checkDebugAarMetadata UP-TO-DATE
> Task :richtext-commonmark:processDebugNavigationResources UP-TO-DATE
> Task :richtext-markdown:processDebugNavigationResources UP-TO-DATE
> Task :richtext-ui:processDebugNavigationResources UP-TO-DATE
> Task :richtext-ui-material3:processDebugNavigationResources UP-TO-DATE
> Task :android-sample:processDebugNavigationResources UP-TO-DATE
> Task :android-sample:compileDebugNavigationResources UP-TO-DATE
> Task :android-sample:generateDebugResValues UP-TO-DATE
> Task :richtext-commonmark:generateDebugResValues UP-TO-DATE
> Task :richtext-commonmark:generateDebugResources UP-TO-DATE
> Task :richtext-commonmark:packageDebugResources UP-TO-DATE
> Task :richtext-markdown:generateDebugResValues UP-TO-DATE
> Task :richtext-markdown:generateDebugResources UP-TO-DATE
> Task :richtext-markdown:packageDebugResources UP-TO-DATE
> Task :richtext-ui:generateDebugResValues UP-TO-DATE
> Task :richtext-ui:generateDebugResources UP-TO-DATE
> Task :richtext-ui:packageDebugResources UP-TO-DATE
> Task :richtext-ui-material3:generateDebugResValues UP-TO-DATE
> Task :richtext-ui-material3:generateDebugResources UP-TO-DATE
> Task :richtext-ui-material3:packageDebugResources UP-TO-DATE
> Task :android-sample:mapDebugSourceSetPaths UP-TO-DATE
> Task :android-sample:generateDebugResources UP-TO-DATE
> Task :android-sample:mergeDebugResources UP-TO-DATE
> Task :android-sample:packageDebugResources UP-TO-DATE
> Task :android-sample:parseDebugLocalResources UP-TO-DATE
> Task :android-sample:createDebugCompatibleScreenManifests UP-TO-DATE
> Task :android-sample:extractDeepLinksDebug UP-TO-DATE
> Task :richtext-commonmark:extractDeepLinksDebug UP-TO-DATE
> Task :richtext-commonmark:processDebugManifest UP-TO-DATE
> Task :richtext-markdown:extractDeepLinksDebug UP-TO-DATE
> Task :richtext-markdown:processDebugManifest UP-TO-DATE
> Task :richtext-ui:extractDeepLinksDebug UP-TO-DATE
> Task :richtext-ui:processDebugManifest UP-TO-DATE
> Task :richtext-ui-material3:extractDeepLinksDebug UP-TO-DATE
> Task :richtext-ui-material3:processDebugManifest UP-TO-DATE
> Task :android-sample:processDebugMainManifest UP-TO-DATE
> Task :android-sample:processDebugManifest UP-TO-DATE
> Task :android-sample:processDebugManifestForPackage UP-TO-DATE
> Task :richtext-commonmark:compileDebugLibraryResources UP-TO-DATE
> Task :richtext-commonmark:parseDebugLocalResources UP-TO-DATE
> Task :richtext-commonmark:generateDebugRFile UP-TO-DATE
> Task :richtext-markdown:compileDebugLibraryResources UP-TO-DATE
> Task :richtext-markdown:parseDebugLocalResources UP-TO-DATE
> Task :richtext-markdown:generateDebugRFile UP-TO-DATE
> Task :richtext-ui:compileDebugLibraryResources UP-TO-DATE
> Task :richtext-ui:parseDebugLocalResources UP-TO-DATE
> Task :richtext-ui:generateDebugRFile UP-TO-DATE
> Task :richtext-ui-material3:compileDebugLibraryResources UP-TO-DATE
> Task :richtext-ui-material3:parseDebugLocalResources UP-TO-DATE
> Task :richtext-ui-material3:generateDebugRFile UP-TO-DATE
> Task :android-sample:processDebugResources UP-TO-DATE
> Task :richtext-commonmark:kmpPartiallyResolvedDependenciesChecker
> Task :richtext-commonmark:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :richtext-commonmark:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-commonmark:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-commonmark:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :richtext-commonmark:generateResourceAccessorsForAndroidMain SKIPPED
> Task :richtext-commonmark:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-commonmark:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-commonmark:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :richtext-commonmark:generateResourceAccessorsForCommonMain SKIPPED
> Task :richtext-commonmark:generateActualResourceCollectorsForAndroidMain SKIPPED
> Task :richtext-commonmark:generateComposeResClass SKIPPED
> Task :richtext-commonmark:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :richtext-commonmark:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-commonmark:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-commonmark:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :richtext-commonmark:generateResourceAccessorsForAndroidDebug SKIPPED
> Task :richtext-markdown:kmpPartiallyResolvedDependenciesChecker
> Task :richtext-markdown:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidMain SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForCommonMain SKIPPED
> Task :richtext-markdown:generateActualResourceCollectorsForAndroidMain SKIPPED
> Task :richtext-markdown:generateComposeResClass SKIPPED
> Task :richtext-markdown:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :richtext-markdown:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-markdown:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-markdown:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :richtext-markdown:generateResourceAccessorsForAndroidDebug SKIPPED
> Task :richtext-ui:kmpPartiallyResolvedDependenciesChecker
> Task :richtext-ui:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidMain SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForCommonMain SKIPPED
> Task :richtext-ui:generateActualResourceCollectorsForAndroidMain SKIPPED
> Task :richtext-ui:generateComposeResClass SKIPPED
> Task :richtext-ui:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :richtext-ui:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-ui:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-ui:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :richtext-ui:generateResourceAccessorsForAndroidDebug SKIPPED
> Task :richtext-ui:compileDebugKotlinAndroid UP-TO-DATE
> Task :richtext-ui:javaPreCompileDebug UP-TO-DATE
> Task :richtext-ui:compileDebugJavaWithJavac NO-SOURCE
> Task :richtext-ui:bundleLibCompileToJarDebug UP-TO-DATE
> Task :richtext-markdown:compileDebugKotlinAndroid UP-TO-DATE
> Task :richtext-markdown:javaPreCompileDebug UP-TO-DATE
> Task :richtext-markdown:compileDebugJavaWithJavac NO-SOURCE
> Task :richtext-markdown:bundleLibCompileToJarDebug UP-TO-DATE
> Task :richtext-commonmark:compileDebugKotlinAndroid UP-TO-DATE
> Task :richtext-commonmark:javaPreCompileDebug UP-TO-DATE
> Task :richtext-commonmark:compileDebugJavaWithJavac NO-SOURCE
> Task :richtext-commonmark:bundleLibCompileToJarDebug UP-TO-DATE
> Task :richtext-ui-material3:kmpPartiallyResolvedDependenciesChecker
> Task :richtext-ui-material3:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :richtext-ui-material3:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-ui-material3:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :richtext-ui-material3:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :richtext-ui-material3:generateResourceAccessorsForAndroidMain SKIPPED
> Task :richtext-ui-material3:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-ui-material3:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :richtext-ui-material3:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :richtext-ui-material3:generateResourceAccessorsForCommonMain SKIPPED
> Task :richtext-ui-material3:generateActualResourceCollectorsForAndroidMain SKIPPED
> Task :richtext-ui-material3:generateComposeResClass SKIPPED
> Task :richtext-ui-material3:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :richtext-ui-material3:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-ui-material3:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :richtext-ui-material3:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :richtext-ui-material3:generateResourceAccessorsForAndroidDebug SKIPPED
> Task :richtext-ui-material3:compileDebugKotlinAndroid UP-TO-DATE
> Task :richtext-ui-material3:javaPreCompileDebug UP-TO-DATE
> Task :richtext-ui-material3:compileDebugJavaWithJavac NO-SOURCE
> Task :richtext-ui-material3:bundleLibCompileToJarDebug UP-TO-DATE
> Task :android-sample:compileDebugKotlin UP-TO-DATE
> Task :android-sample:javaPreCompileDebug UP-TO-DATE
> Task :android-sample:compileDebugJavaWithJavac NO-SOURCE
> Task :android-sample:bundleDebugClassesToRuntimeJar UP-TO-DATE
> Task :android-sample:bundleDebugClassesToCompileJar UP-TO-DATE
> Task :android-sample:generateDebugComposePreviewRobolectricTests UP-TO-DATE
> Task :android-sample:compileDebugUnitTestKotlin UP-TO-DATE
> Task :android-sample:preDebugUnitTestBuild UP-TO-DATE
> Task :android-sample:javaPreCompileDebugUnitTest UP-TO-DATE
> Task :android-sample:compileDebugUnitTestJavaWithJavac NO-SOURCE
> Task :android-sample:mergeDebugShaders UP-TO-DATE
> Task :android-sample:compileDebugShaders NO-SOURCE
> Task :android-sample:generateDebugAssets UP-TO-DATE
> Task :richtext-commonmark:mergeDebugShaders UP-TO-DATE
> Task :richtext-commonmark:compileDebugShaders NO-SOURCE
> Task :richtext-commonmark:copyDebugComposeResourcesToAndroidAssets UP-TO-DATE
> Task :richtext-commonmark:debugAssetsCopyForAGP NO-SOURCE
> Task :richtext-commonmark:generateDebugAssets UP-TO-DATE
> Task :richtext-commonmark:mergeDebugAssets UP-TO-DATE
> Task :richtext-markdown:mergeDebugShaders UP-TO-DATE
> Task :richtext-markdown:compileDebugShaders NO-SOURCE
> Task :richtext-markdown:copyDebugComposeResourcesToAndroidAssets UP-TO-DATE
> Task :richtext-markdown:debugAssetsCopyForAGP NO-SOURCE
> Task :richtext-markdown:generateDebugAssets UP-TO-DATE
> Task :richtext-markdown:mergeDebugAssets UP-TO-DATE
> Task :richtext-ui:mergeDebugShaders UP-TO-DATE
> Task :richtext-ui:compileDebugShaders NO-SOURCE
> Task :richtext-ui:copyDebugComposeResourcesToAndroidAssets UP-TO-DATE
> Task :richtext-ui:debugAssetsCopyForAGP NO-SOURCE
> Task :richtext-ui:generateDebugAssets UP-TO-DATE
> Task :richtext-ui:mergeDebugAssets UP-TO-DATE
> Task :richtext-ui-material3:mergeDebugShaders UP-TO-DATE
> Task :richtext-ui-material3:compileDebugShaders NO-SOURCE
> Task :richtext-ui-material3:copyDebugComposeResourcesToAndroidAssets UP-TO-DATE
> Task :richtext-ui-material3:debugAssetsCopyForAGP NO-SOURCE
> Task :richtext-ui-material3:generateDebugAssets UP-TO-DATE
> Task :richtext-ui-material3:mergeDebugAssets UP-TO-DATE
> Task :android-sample:mergeDebugAssets UP-TO-DATE
> Task :android-sample:packageDebugUnitTestForUnitTest UP-TO-DATE
> Task :android-sample:processDebugUnitTestManifest UP-TO-DATE
> Task :android-sample:generateDebugUnitTestConfig UP-TO-DATE
> Task :android-sample:processDebugJavaRes UP-TO-DATE
> Task :android-sample:processDebugUnitTestJavaRes UP-TO-DATE
> Task :richtext-commonmark:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :richtext-commonmark:processDebugJavaRes UP-TO-DATE
> Task :richtext-markdown:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :richtext-markdown:processDebugJavaRes UP-TO-DATE
> Task :richtext-ui:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :richtext-ui:processDebugJavaRes UP-TO-DATE
> Task :richtext-ui-material3:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :richtext-ui-material3:processDebugJavaRes UP-TO-DATE
> Task :android-sample:testDebugUnitTest UP-TO-DATE
> Task :android-sample:finalizeTestRoborazziDebug SKIPPED

BUILD SUCCESSFUL in 1s
115 actionable tasks: 4 executed, 111 up-to-date