### PR TITLE
[compose-richtext] Avoid inactive streaming accent layouts

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -161,36 +161,44 @@ public fun RichTextScope.Text(
     )
   }
   val underlineAlphaForOffset = animatedResult?.alphaForOffset
-  val accentTextMeasurer = rememberTextMeasurer(cacheSize = 1)
-  val accentOverlayText = remember(
-    animatedResult?.accentOverlayText,
-    textAlign,
-    textDirection,
-  ) {
-    animatedResult?.accentOverlayText
-      ?.let { applyParagraphStyle(it, textAlign, textDirection) }
-  }
-  val accentTextLayoutResult = remember(accentOverlayText, textLayoutResult) {
-    val layoutInput = textLayoutResult?.layoutInput ?: return@remember null
-    accentOverlayText?.let { text ->
-      accentTextMeasurer.measure(
-        text = text,
-        style = layoutInput.style,
-        overflow = layoutInput.overflow,
-        softWrap = layoutInput.softWrap,
-        maxLines = layoutInput.maxLines,
-        placeholders = layoutInput.placeholders,
-        constraints = layoutInput.constraints,
-        layoutDirection = layoutInput.layoutDirection,
-        density = layoutInput.density,
-        fontFamilyResolver = layoutInput.fontFamilyResolver,
-      )
+  val streamingTextAccent = renderOptions.streamingTextAccent
+  val streamingTextAccentAnimations = animatedResult?.streamingTextAccentAnimations.orEmpty()
+  val hasStreamingTextAccentOverlay =
+    streamingTextAccent != null && streamingTextAccentAnimations.isNotEmpty()
+  val accentTextLayoutResult = if (hasStreamingTextAccentOverlay) {
+    val accentTextMeasurer = rememberTextMeasurer(cacheSize = 1)
+    val accentOverlayText = remember(
+      animatedResult?.accentOverlayText,
+      textAlign,
+      textDirection,
+    ) {
+      animatedResult?.accentOverlayText
+        ?.let { applyParagraphStyle(it, textAlign, textDirection) }
     }
+    remember(accentOverlayText, textLayoutResult) {
+      val layoutInput = textLayoutResult?.layoutInput ?: return@remember null
+      accentOverlayText?.let { text ->
+        accentTextMeasurer.measure(
+          text = text,
+          style = layoutInput.style,
+          overflow = layoutInput.overflow,
+          softWrap = layoutInput.softWrap,
+          maxLines = layoutInput.maxLines,
+          placeholders = layoutInput.placeholders,
+          constraints = layoutInput.constraints,
+          layoutDirection = layoutInput.layoutDirection,
+          density = layoutInput.density,
+          fontFamilyResolver = layoutInput.fontFamilyResolver,
+        )
+      }
+    }
+  } else {
+    null
   }
   val streamingTextAccentModifier = Modifier.streamingTextAccentOverlay(
-    accentColor = renderOptions.streamingTextAccent?.color,
+    accentColor = streamingTextAccent?.color,
     textLayoutResult = { accentTextLayoutResult },
-    animations = animatedResult?.streamingTextAccentAnimations.orEmpty(),
+    animations = streamingTextAccentAnimations,
   )
 
   val underlineModifier = if (underlineSpecs.isNotEmpty()) {
@@ -808,7 +816,7 @@ private fun Modifier.streamingTextAccentOverlay(
   accentColor: Color?,
   textLayoutResult: () -> TextLayoutResult?,
   animations: Map<Int, StreamingTextAccentAnimation>,
-): Modifier = if (accentColor == null) {
+): Modifier = if (accentColor == null || animations.isEmpty()) {
   this
 } else {
   drawWithContent {


### PR DESCRIPTION
## What changed

- Skip preparing the streaming accent overlay layout unless an accent is configured and at least one accent animation is active.
- Make the overlay draw modifier a no-op when there are no active accent animations.

## Why

The streaming accent API is optional, but the merged implementation prepared a second text layout for every animated rich text leaf before checking whether the accent feature was active. Existing `animate = true` callers without `streamingTextAccent` should not pay that extra layout cost.

## Validation

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.10/libexec/openjdk.jdk/Contents/Home ./gradlew :richtext-ui:jvmTest`
- `git diff --check`
