### PR TITLE
Use admission time for streaming accent decay

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -388,6 +388,27 @@ public class MarkdownAnimationState {
   ): Float =
     (1f - (now - accent.decayStartTimeMark).inWholeMilliseconds /
       accent.decayDurationMs.toFloat()).coerceIn(0f, 1f)
+
+  internal fun streamingTextAccentInitialAlpha(
+    accent: StreamingTextAccent,
+    admissionTimeMark: ComparableTimeMark,
+    startTimeMark: ComparableTimeMark,
+  ): Float =
+    minOf(
+      streamingTextAccentInitialAlpha(accent, admissionTimeMark),
+      streamingTextAccentInitialAlpha(accent, startTimeMark),
+    )
+
+  internal fun streamingTextAccentDurationMs(
+    accent: StreamingTextAccent,
+    startTimeMark: ComparableTimeMark,
+  ): Int {
+    val elapsedDecayMs = (startTimeMark - accent.decayStartTimeMark).inWholeMilliseconds
+    val remainingDecayMs = accent.decayDurationMs - elapsedDecayMs
+    return minOf(accent.fadeOutMs.toLong(), remainingDecayMs)
+      .coerceAtLeast(0)
+      .toInt()
+  }
 }
 
 private data class AnimatedTextResult(
@@ -424,20 +445,30 @@ private fun rememberAnimatedTextResult(
     startTimeMark: ComparableTimeMark,
     admissionTimeMark: ComparableTimeMark ->
     val accent = renderOptions.streamingTextAccent ?: return@addAccent
-    // Decay admission when text becomes accent-eligible, not when delayed reveal begins.
-    val initialAlpha = sharedAnimationState.streamingTextAccentInitialAlpha(accent, admissionTimeMark)
+    // Admission decides whether text belongs to the opening response, while scheduled reveal time
+    // controls the visible strength so delayed words do not pop in at full accent intensity.
+    val initialAlpha = sharedAnimationState.streamingTextAccentInitialAlpha(
+      accent = accent,
+      admissionTimeMark = admissionTimeMark,
+      startTimeMark = startTimeMark,
+    )
     if (initialAlpha <= 0f) return@addAccent
+    val durationMs = sharedAnimationState.streamingTextAccentDurationMs(
+      accent = accent,
+      startTimeMark = startTimeMark,
+    )
+    if (durationMs <= 0) return@addAccent
     val elapsedMs = startTimeMark.elapsedMilliseconds().toInt()
-    if (elapsedMs >= accent.fadeOutMs) return@addAccent
+    if (elapsedMs >= durationMs) return@addAccent
 
     if (streamingTextAccentAnimations.size >= MaximumStreamingTextAccentAnimationCount) {
-      streamingTextAccentAnimations.keys.minOrNull()?.let(streamingTextAccentAnimations::remove)
+      return@addAccent
     }
     val id = nextStreamingTextAccentAnimationId.intValue++
     val animation = StreamingTextAccentAnimation(
       start = start,
       end = end,
-      fadeOutMs = accent.fadeOutMs,
+      durationMs = durationMs,
       excludesEmoji = accent.excludesEmoji,
       initialAlpha = initialAlpha,
       elapsedMs = elapsedMs.toFloat(),
@@ -596,7 +627,7 @@ private class TextAnimation(val startIndex: Int) {
 private class StreamingTextAccentAnimation(
   val start: Int,
   val end: Int,
-  val fadeOutMs: Int,
+  val durationMs: Int,
   val excludesEmoji: Boolean,
   private val initialAlpha: Float,
   elapsedMs: Float,
@@ -604,11 +635,10 @@ private class StreamingTextAccentAnimation(
 ) {
   var hasStarted by mutableStateOf(hasStarted)
   var elapsedMs by mutableFloatStateOf(elapsedMs)
-  val durationMs = fadeOutMs
 
   fun alpha(): Float {
     if (!hasStarted) return 0f
-    val progress = (elapsedMs / fadeOutMs).coerceIn(0f, 1f)
+    val progress = (elapsedMs / durationMs).coerceIn(0f, 1f)
     return initialAlpha * (1f - StreamingTextAccentFadeEasing.transform(progress))
   }
 }
@@ -972,7 +1002,7 @@ private data class DynamicSolidColor(private val color: Color, private val alpha
 }
 
 private const val CombiningEnclosingKeycap = 0x20E3
-private const val MaximumStreamingTextAccentAnimationCount = 24
+private const val MaximumStreamingTextAccentAnimationCount = 48
 private val StreamingTextAccentFadeEasing = CubicBezierEasing(0.42f, 0f, 0.58f, 1f)
 private const val VariationSelector16 = 0xFE0F
 private const val ZeroWidthJoiner = 0x200D

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/Text.kt
@@ -418,9 +418,14 @@ private fun rememberAnimatedTextResult(
   val lastAnimationIndex = remember { mutableIntStateOf(-1) }
   val lastPhrases = remember { mutableStateOf(PhraseAnnotatedString()) }
   val lastStreamingTextAccent = remember { mutableStateOf<StreamingTextAccent?>(null) }
-  val addStreamingTextAccentAnimation = addAccent@{ start: Int, end: Int, startTimeMark: ComparableTimeMark ->
+  val addStreamingTextAccentAnimation = addAccent@{
+    start: Int,
+    end: Int,
+    startTimeMark: ComparableTimeMark,
+    admissionTimeMark: ComparableTimeMark ->
     val accent = renderOptions.streamingTextAccent ?: return@addAccent
-    val initialAlpha = sharedAnimationState.streamingTextAccentInitialAlpha(accent, startTimeMark)
+    // Decay admission when text becomes accent-eligible, not when delayed reveal begins.
+    val initialAlpha = sharedAnimationState.streamingTextAccentInitialAlpha(accent, admissionTimeMark)
     if (initialAlpha <= 0f) return@addAccent
     val elapsedMs = startTimeMark.elapsedMilliseconds().toInt()
     if (elapsedMs >= accent.fadeOutMs) return@addAccent
@@ -457,7 +462,9 @@ private fun rememberAnimatedTextResult(
       streamingTextAccentAnimations.remove(id)
     }
   }
-  val addStreamingTextAccentAnimations = addAccents@{ phrases: PhraseAnnotatedString ->
+  val addStreamingTextAccentAnimations = addAccents@{
+    phrases: PhraseAnnotatedString,
+    admissionTimeMark: ComparableTimeMark ->
     if (renderOptions.streamingTextAccent == null) return@addAccents
     streamingTextAccentAdditions(
       phraseSegments = phrases.phraseSegments,
@@ -469,6 +476,7 @@ private fun rememberAnimatedTextResult(
           addition.range.start,
           addition.range.end,
           startTimeMark,
+          admissionTimeMark,
         )
       }
     }
@@ -507,7 +515,7 @@ private fun rememberAnimatedTextResult(
           animations.remove(phraseIndex)
         }
       }
-    addStreamingTextAccentAnimations(phrases)
+    addStreamingTextAccentAnimations(phrases, monotonicTimeMark())
   }
   LaunchedEffect(isLeafText, annotated, renderOptions.streamingTextAccent) {
     val shouldAccentExistingText =
@@ -524,7 +532,7 @@ private fun rememberAnimatedTextResult(
     if (hasNewPhrases) {
       updatePhrases(phrases)
     } else if (shouldAccentExistingText) {
-      addStreamingTextAccentAnimations(phrases)
+      addStreamingTextAccentAnimations(phrases, monotonicTimeMark())
     } else {
       return@LaunchedEffect
     }

--- a/richtext-ui/src/commonTest/kotlin/com/halilibo/richtext/ui/string/StreamingTextAccentRangesTest.kt
+++ b/richtext-ui/src/commonTest/kotlin/com/halilibo/richtext/ui/string/StreamingTextAccentRangesTest.kt
@@ -122,6 +122,63 @@ class StreamingTextAccentRangesTest {
   }
 
   @Test
+  fun initialAlphaUsesScheduledRevealTimeForStrength() {
+    val decayStartTimeMark = TimeSource.Monotonic.markNow()
+    val accent = StreamingTextAccent(
+      color = Color.Red,
+      decayDurationMs = 2_000,
+      decayStartTimeMark = decayStartTimeMark,
+    )
+
+    assertEquals(
+      0.25f,
+      MarkdownAnimationState().streamingTextAccentInitialAlpha(
+        accent = accent,
+        admissionTimeMark = decayStartTimeMark + 200.milliseconds,
+        startTimeMark = decayStartTimeMark + 1_500.milliseconds,
+      ),
+    )
+  }
+
+  @Test
+  fun durationUsesConfiguredFadeWithinDecayWindow() {
+    val decayStartTimeMark = TimeSource.Monotonic.markNow()
+    val accent = StreamingTextAccent(
+      color = Color.Red,
+      fadeOutMs = 600,
+      decayDurationMs = 2_000,
+      decayStartTimeMark = decayStartTimeMark,
+    )
+
+    assertEquals(
+      600,
+      MarkdownAnimationState().streamingTextAccentDurationMs(
+        accent = accent,
+        startTimeMark = decayStartTimeMark + 500.milliseconds,
+      ),
+    )
+  }
+
+  @Test
+  fun durationEndsAtDecayWindow() {
+    val decayStartTimeMark = TimeSource.Monotonic.markNow()
+    val accent = StreamingTextAccent(
+      color = Color.Red,
+      fadeOutMs = 2_000,
+      decayDurationMs = 2_000,
+      decayStartTimeMark = decayStartTimeMark,
+    )
+
+    assertEquals(
+      500,
+      MarkdownAnimationState().streamingTextAccentDurationMs(
+        accent = accent,
+        startTimeMark = decayStartTimeMark + 1_500.milliseconds,
+      ),
+    )
+  }
+
+  @Test
   fun additionsUseImmutableAppendedRanges() {
     val accentedEndByAnimationIndex = mutableMapOf<Int, Int>()
 


### PR DESCRIPTION
## Summary

- Uses both admission time and scheduled reveal time when deciding streaming accent strength.
- Caps each accent overlay duration at the shared decay window so delayed text does not outlive the opening accent treatment.
- Keeps existing animation count bounded by skipping excess accent overlays instead of evicting active ones.

## Why

Streaming text can reveal adjacent markdown blocks at slightly different times. If each overlay only uses its local reveal timing, already-revealed text can lose the accent while the next block is still starting, making the transition look inconsistent. This keeps the treatment tied to the shared opening window while preserving per-segment reveal timing.

## Testing

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.10/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/pat/Library/Android/sdk ./gradlew :richtext-ui:check`
